### PR TITLE
Add typings for global clients

### DIFF
--- a/functions/communication/sendEmail.ts
+++ b/functions/communication/sendEmail.ts
@@ -29,12 +29,12 @@ export const sendEmail = async (request: SendEmailMessageRequestParams): Promise
 	let error: string | undefined;
 	let msgId: string | undefined;
 
-	if (!global.gmailClient) {
-		const mailer = new GmailMailer();
-		try {
-			await mailer.initializeClient({});
-			global.gmailClient = mailer;
-		} catch (err: any) {
+        if (!global.gmailClient) {
+                const mailer = new GmailMailer();
+                try {
+                        await mailer.initializeClient({});
+                        global.gmailClient = mailer;
+                } catch (err: any) {
 			error = `Error initializing mailer client: ${err.message}`;
 			const duration = `${Date.now() - startTimestamp} ms`;
 			return {
@@ -49,9 +49,11 @@ export const sendEmail = async (request: SendEmailMessageRequestParams): Promise
 				error,
 			};
 		}
-	}
+        }
 
-	try {
+        const gmailClient = global.gmailClient as GmailMailer;
+
+        try {
 		const encodedSubjectResponse = encodeEmailContent({ content: subject ?? '', type: EncodingType.Subject });
 		if (!encodedSubjectResponse.isEncoded) {
 			throw new Error(`Error encoding subject: ${encodedSubjectResponse.message}`);
@@ -60,7 +62,7 @@ export const sendEmail = async (request: SendEmailMessageRequestParams): Promise
 
 		const { isHtml } = detectHtml({ content: body });
 
-		const result = await global.gmailClient.sendEmail({
+                const result = await gmailClient.sendEmail({
 			recipientEmail: to,
 			senderName,
 			subject: encodedSubject,

--- a/functions/communication/textToAudio.ts
+++ b/functions/communication/textToAudio.ts
@@ -6,11 +6,11 @@ import { promises as fsPromises, createReadStream } from 'fs';
 import { AudioConfig, SpeechSynthesizer, ResultReason, SpeechSynthesisOutputFormat } from 'microsoft-cognitiveservices-speech-sdk';
 
 const initializeSynthesizer = (filePath: string): SpeechSynthesizer => {
-	if (!global.speechSynthesizer) {
-		const audioConfig = AudioConfig.fromAudioFileOutput(filePath);
-		global.speechSynthesizer = new SpeechSynthesizer(speechConfig, audioConfig);
-	}
-	return global.speechSynthesizer;
+        if (!global.speechSynthesizer) {
+                const audioConfig = AudioConfig.fromAudioFileOutput(filePath);
+                global.speechSynthesizer = new SpeechSynthesizer(speechConfig, audioConfig);
+        }
+        return global.speechSynthesizer as SpeechSynthesizer;
 };
 
 export const textToAudioFile = async ({ body }: { body: any }): Promise<any> => {

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+import { GmailMailer } from 'gmail-node-mailer';
+import { SpeechSynthesizer } from 'microsoft-cognitiveservices-speech-sdk';
+
+declare global {
+    var gmailClient: GmailMailer | undefined;
+    var speechSynthesizer: SpeechSynthesizer | undefined;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- declare `global.gmailClient` and `global.speechSynthesizer`
- reference new global typings in email and text-to-speech helpers

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_685106471420832488748e8890db1620