### PR TITLE
Update resolveLocation API URL to HTTPS

### DIFF
--- a/functions/resolvers/resolveLocation.ts
+++ b/functions/resolvers/resolveLocation.ts
@@ -59,7 +59,7 @@ const getAddressByCoordinates = async (lat: number, lon: number): Promise<any> =
 		baseEnvName: 'OPEN_WEATHER_API_KEY_',
 	});
 
-	const apiUrl = `http://api.openweathermap.org/geo/1.0/reverse?lat=${lat}&lon=${lon}&limit=1&appid=${apiKey}`;
+        const apiUrl = `https://api.openweathermap.org/geo/1.0/reverse?lat=${lat}&lon=${lon}&limit=1&appid=${apiKey}`;
 
 	const data = await fetchCoordinates(apiUrl);
 	if (data && data.length > 0) {


### PR DESCRIPTION
## Summary
- use `https` for OpenWeatherMap reverse geocoding

## Testing
- `npx prettier --version`


------
https://chatgpt.com/codex/tasks/task_b_68510661ba108324b9e9fb9d41089fda