### PR TITLE
Fix missing Google service account handling

### DIFF
--- a/functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc.ts
+++ b/functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc.ts
@@ -1,7 +1,19 @@
 import { google } from 'googleapis';
 import { VercelRequest } from '@vercel/node';
 
-const serviceAccount = JSON.parse(process.env.GDRIVE_SERVICE_ACCOUNT_JSON as string);
+function getServiceAccount() {
+	const json = process.env.GDRIVE_SERVICE_ACCOUNT_JSON;
+	if (!json) {
+		throw new Error('Google service account configuration is required');
+	}
+	try {
+		return JSON.parse(json);
+	} catch {
+		throw new Error('Invalid JSON in GDRIVE_SERVICE_ACCOUNT_JSON');
+	}
+}
+
+const serviceAccount = getServiceAccount();
 const SCOPES = ['https://www.googleapis.com/auth/drive'];
 
 interface FileCreationResponse {

--- a/functions/googleBusinessStuff/setFileEditPermissions.ts
+++ b/functions/googleBusinessStuff/setFileEditPermissions.ts
@@ -1,7 +1,19 @@
 import { google } from 'googleapis';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 
-const serviceAccount = JSON.parse(process.env.GDRIVE_SERVICE_ACCOUNT_JSON as string);
+function getServiceAccount() {
+	const json = process.env.GDRIVE_SERVICE_ACCOUNT_JSON;
+	if (!json) {
+		throw new Error('Google service account configuration is required');
+	}
+	try {
+		return JSON.parse(json);
+	} catch {
+		throw new Error('Invalid JSON in GDRIVE_SERVICE_ACCOUNT_JSON');
+	}
+}
+
+const serviceAccount = getServiceAccount();
 const SCOPES = ['https://www.googleapis.com/auth/drive'];
 
 const auth = new google.auth.JWT({

--- a/utils/updateGoogleDriveFileDescription.ts
+++ b/utils/updateGoogleDriveFileDescription.ts
@@ -1,6 +1,18 @@
 import { google, drive_v3 } from 'googleapis';
 
-const serviceAccount = JSON.parse(process.env.GDRIVE_SERVICE_ACCOUNT_JSON as string);
+function getServiceAccount() {
+	const json = process.env.GDRIVE_SERVICE_ACCOUNT_JSON;
+	if (!json) {
+		throw new Error('Google service account configuration is required');
+	}
+	try {
+		return JSON.parse(json);
+	} catch {
+		throw new Error('Invalid JSON in GDRIVE_SERVICE_ACCOUNT_JSON');
+	}
+}
+
+const serviceAccount = getServiceAccount();
 const SCOPES = ['https://www.googleapis.com/auth/drive'];
 
 const auth = new google.auth.JWT({


### PR DESCRIPTION
## Summary
- validate Google Drive service account JSON before using it

## Testing
- `npx prettier --write functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc.ts functions/googleBusinessStuff/setFileEditPermissions.ts utils/updateGoogleDriveFileDescription.ts`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68510664625c8324a3fcb8f518d54658