### PR TITLE
Refactor LocationInput

### DIFF
--- a/functions/resolvers/locationTypes.ts
+++ b/functions/resolvers/locationTypes.ts
@@ -1,12 +1,3 @@
-export interface LocationInput {
-	zipCode?: string;
-	lat?: number;
-	lon?: number;
-	city?: string;
-	state?: string;
-	country?: string;
-}
-
 export interface LocationOutput {
 	zipCode: string;
 	lat: number;


### PR DESCRIPTION
## Summary
- remove duplicate interface definition for `LocationInput`

## Testing
- `npm run build` *(fails: Cannot find module 'geo-tz', '@vercel/node', ...)*

------
https://chatgpt.com/codex/tasks/task_b_68510970ee1083248d084c653c56b703