### PR TITLE
Fix build by creating output dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc && mkdir -p public",
     "test": "echo \"No tests\"",
     "lint": "eslint \"**/*.ts\"",
     "format": "prettier --write \"**/*.ts\""

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title>Toolbelt</title><p>Build artifacts</p>


### PR DESCRIPTION
## Summary
- ensure a `public` directory exists for Vercel
- run TypeScript with more heap to avoid OOM

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68510f8169b48324b79c1dc5d86fc161