### PR TITLE
Add typed request/response interfaces

### DIFF
--- a/functions/searchGoogle/googleImageSearch.ts
+++ b/functions/searchGoogle/googleImageSearch.ts
@@ -2,7 +2,7 @@ import gis from 'g-i-s';
 
 import { VercelRequest } from '@vercel/node';
 import { parseQueryParams } from '../../utils/parseQueryParams';
-import { ImageResult, ImageSearchOptions } from './searchGoogleTypes';
+import { ImageResult, ImageSearchOptions, ImageSearchResponse } from './searchGoogleTypes';
 
 const imageSearch = (options: ImageSearchOptions): Promise<ImageResult[]> => {
 	if (options.size) {
@@ -28,7 +28,7 @@ const imageSearch = (options: ImageSearchOptions): Promise<ImageResult[]> => {
 	});
 };
 
-export const googleImageSearch = async (request: VercelRequest): Promise<any> => {
+export const googleImageSearch = async (request: VercelRequest): Promise<ImageSearchResponse> => {
 	try {
 		let requestBody: ImageSearchOptions[];
 
@@ -51,7 +51,7 @@ export const googleImageSearch = async (request: VercelRequest): Promise<any> =>
 			};
 		}
 
-		const results = await Promise.all(
+                const results: ImageResult[][] = await Promise.all(
 			requestBody.map(async options => {
 				if (!options.searchTerm) {
 					throw new Error('Search term is required');

--- a/functions/searchGoogle/googleWebSearch.ts
+++ b/functions/searchGoogle/googleWebSearch.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import { getNextEnvKey } from 'envholster';
 import { parseQueryParams } from '../../utils/parseQueryParams';
-import { SerpSearchRequest } from './searchGoogleTypes';
+import { SerpSearchRequest, WebSearchResponse, WebSearchResult } from './searchGoogleTypes';
 import { VercelRequest } from '@vercel/node';
 
-export const searchGoogle = async (request: VercelRequest) => {
+export const searchGoogle = async (request: VercelRequest): Promise<WebSearchResponse> => {
 	try {
 		const { key: apiKey } = await getNextEnvKey({ baseEnvName: 'SCALE_SERP_API_KEY_' });
 
@@ -25,8 +25,8 @@ export const searchGoogle = async (request: VercelRequest) => {
 			};
 		}
 
-		const results = await Promise.all(
-			requests.map(async req => {
+                const results: WebSearchResult[] = await Promise.all(
+                        requests.map(async req => {
 				const params: any = {
 					api_key: apiKey,
 					q: req.searchTerm,

--- a/functions/searchGoogle/searchGoogleTypes.ts
+++ b/functions/searchGoogle/searchGoogleTypes.ts
@@ -85,7 +85,26 @@ export interface ImageSearchOptions {
 }
 
 export interface ImageResult {
-	url: string;
-	width: number;
-	height: number;
+        url: string;
+        width: number;
+        height: number;
+}
+
+export interface WebSearchResult {
+        searchQuery: string;
+        organic_results: Omit<OrganicResult, 'prerender' | 'page' | 'position' | 'position_overall' | 'block_position'>[];
+        searchUrl: string;
+        metaDataUrl: string;
+}
+
+export interface WebSearchResponse {
+        status: boolean;
+        message: string;
+        data: WebSearchResult | WebSearchResult[];
+}
+
+export interface ImageSearchResponse {
+        status: boolean;
+        message: string;
+        data: ImageResult[][];
 }

--- a/functions/weather/fetchExtendedWeather.ts
+++ b/functions/weather/fetchExtendedWeather.ts
@@ -1,7 +1,12 @@
 import { getVisualWeather } from './visualWeatherFunction';
+import { VercelRequest } from '@vercel/node';
+import { WeatherRequest, ExtendedWeatherResponse } from './weatherTypes';
 
-export const fetchExtendedWeather = async request => {
-	const { city, state, zipCode, lat, lon } = request.body;
+export const fetchExtendedWeather = async (
+        request: VercelRequest
+): Promise<ExtendedWeatherResponse> => {
+        const { city, state, zipCode, lat, lon } =
+                request.body as WeatherRequest;
 
 	if (!city && !state && !zipCode && (lat === undefined || lon === undefined)) {
 		throw new Error('Please provide either {city, state, country (optional)}, {zipCode}, or {lat, lon}.');

--- a/functions/weather/todaysWeather.ts
+++ b/functions/weather/todaysWeather.ts
@@ -1,13 +1,18 @@
 import axios from 'axios';
 import { getNextEnvKey } from 'envholster';
+import { VercelRequest } from '@vercel/node';
+import { WeatherRequest, TodaysWeatherResponse } from './weatherTypes';
 
-export const fetchTodaysWeatherData = async request => {
+export const fetchTodaysWeatherData = async (
+        request: VercelRequest
+): Promise<TodaysWeatherResponse> => {
 	const { key: weatherApiKey } = await getNextEnvKey({
 		baseEnvName: 'VISUAL_CROSSING_WEATHER_API_KEY_',
 	});
 
-	let location;
-	let { lat, lon, city, state, zipCode, country } = request.body;
+        let location;
+        const { lat, lon, city, state, zipCode, country } =
+                request.body as WeatherRequest;
 	if (lat !== undefined && lon !== undefined) {
 		location = `${lat},${lon}`;
 	} else if (city && state) {

--- a/functions/weather/weatherTypes.ts
+++ b/functions/weather/weatherTypes.ts
@@ -14,3 +14,60 @@ export interface GEOCODE {
 }
 
 export interface LocationInput extends StreetAddress, ZipCode, GEOCODE {}
+
+export interface WeatherRequest extends LocationInput {}
+
+export interface CurrentWeather {
+        datetime: string;
+        temp: number;
+        feelslike: number;
+        humidity: number;
+        dew: number;
+        precip: number;
+        precipprob: number;
+        snow: number;
+        snowdepth: number;
+        windspeed: number;
+        winddir: string;
+        pressure: number;
+        visibility: number;
+        cloudcover: number;
+        solarradiation: number;
+        uvindex: number;
+        conditions: string;
+        sunrise: string;
+        sunset: string;
+        description: string;
+}
+
+export interface TodaysWeatherResponse {
+        location: string;
+        currentWeather: CurrentWeather;
+}
+
+export interface ForecastDay {
+        date: string;
+        dayOfWeek: string;
+        maxTempC: number;
+        minTempC: number;
+        avgTempC: number;
+        maxTempF: number;
+        minTempF: number;
+        avgTempF: number;
+        windSpeed: number;
+        windDir: number;
+        precipitation: number;
+        humidity: number;
+        conditions: string;
+        description: string;
+}
+
+export interface WeeklyWeatherResponse {
+        forecast: ForecastDay[];
+        description: string;
+}
+
+export interface ExtendedWeatherResponse {
+        forecast: ForecastDay[];
+        description: string;
+}

--- a/functions/weather/weeklyWeather.ts
+++ b/functions/weather/weeklyWeather.ts
@@ -1,8 +1,13 @@
 import { getOpenWeather } from './openWeatherFunction';
 import { getVisualWeather } from './visualWeatherFunction';
+import { VercelRequest } from '@vercel/node';
+import { WeatherRequest, WeeklyWeatherResponse } from './weatherTypes';
 
-export const fetchWeeklyWeatherData = async request => {
-	const { city, state, zipCode, lat, lon } = request.body;
+export const fetchWeeklyWeatherData = async (
+        request: VercelRequest
+): Promise<WeeklyWeatherResponse> => {
+        const { city, state, zipCode, lat, lon } =
+                request.body as WeatherRequest;
 
 	if (!city && !state && !zipCode && (lat === undefined || lon === undefined)) {
 		throw new Error('Provide either {city, state, country(optional)}, {zipCode}, or {lat, lon}');


### PR DESCRIPTION
## Summary
- add payload interfaces for weather utilities
- type search Google results and responses
- use new interfaces in weather and search modules

## Testing
- `npx tsc` *(fails: Cannot find module '@vercel/node' and others)*

------
https://chatgpt.com/codex/tasks/task_b_68511499fe50832483b59ae3a63dd928