### PR TITLE
Fix tools load path

### DIFF
--- a/api/toolsHandler.ts
+++ b/api/toolsHandler.ts
@@ -1,53 +1,5 @@
 // Communication functions
-import { sendEmail } from '../functions/communication/sendEmail';
-import { sendTextMessage } from '../functions/communication/sendTextMessage';
-import { textToAudioFile } from '../functions/communication/textToAudio';
-import { audioFileToText } from '../functions/communication/audioToTextFile';
-import { sendWhatsAppMessage } from '../functions/communication/sendWhatsAppMessage';
-import { sendWhatsAppVoiceMessage } from '../functions/communication/sendWhatsAppVoiceMessage';
-import { listenToWhatsAppVoiceAudio } from '../functions/communication/listenToWhatsAppVoiceAudio';
-import { viewAndDescribeWhatsAppImage } from '../functions/communication/viewAndDescribeWhatsAppImage';
-
-// Google search functions
-import { searchGoogle } from '../functions/searchGoogle/googleWebSearch';
-import { googleImageSearch } from '../functions/searchGoogle/googleImageSearch';
-
-// Location resolvers
-import { IPAddressLookUp } from '../functions/ip/ip';
-import { getLocationData } from '../functions/resolvers/location';
-import { googleAddressResolver } from '../functions/resolvers/googleAddressResolver';
-import { parsePhoneNumberHandler } from '../functions/resolvers/phonenumber';
-
-// Tool handling
 import { handleToolOptions } from '../functions/handleToolOptions';
-
-// Weather functions
-import { uploadToCloudinary } from '../functions/weather/uploaders/uploadToCloudinary';
-import { fetchExtendedWeather } from '../functions/weather/fetchExtendedWeather';
-import { fetchWeeklyWeatherData } from '../functions/weather/weeklyWeather';
-import { fetchTodaysWeatherData } from '../functions/weather/todaysWeather';
-
-// Screenshot functions
-import { getWebsiteScreenshot } from '../functions/screenshot/getWebsiteScreenshot';
-
-// Islamic prayer timings
-import { getIslamicPrayerTimingsDay } from '../functions/islamicPrayerTimingsDay';
-import { getIslamicPrayerTimingsWeek } from '../functions/IslamicPrayerTimingsWeek';
-
-// Google business functions
-import {
-	createGoogleDocsFile,
-	updateGoogleDocsFile,
-	updateGoogleSheetsFile,
-	createGoogleSheetsFile,
-	setGoogleFilePermissions,
-} from '../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc';
-
-// Utility functions
-import { getCurrentDateTime } from './getCurrentDateTime';
-import { markWhatsAppMessageRead } from '../functions/communication/markWhatsAppMessageRead';
-import { sendWhatsAppLocation } from '../functions/communication/sendWhatsAppLocation';
-import { requestWhatsAppLocation } from '../functions/communication/requestWhatsAppLocation';
 
 interface AIRequest {
 	functionName: string;
@@ -68,69 +20,129 @@ const handler = async (request: any, response: any) => {
 			throw new Error('Invalid request method');
 		}
 
-		const processRequest = async (request: any) => {
-			console.log({ functionName, request: request.body });
-			switch (functionName) {
-				case 'ipaddresslookup':
-					return await IPAddressLookUp(request);
-				case 'locationresolver':
-					return await getLocationData(request);
-				case 'getwebsitescreenshot':
-					return await getWebsiteScreenshot(request);
-				case 'googlewebsearch':
-					return await searchGoogle(request);
-				case 'gettodaysweather':
-					return await fetchTodaysWeatherData(request);
-				case 'getweeklyforecast':
-					return await fetchWeeklyWeatherData(request);
-				case 'getextendedweather':
-					return await fetchExtendedWeather(request);
-				case 'googleaddressresolver':
-					return await googleAddressResolver(request);
-				case 'parsephonenumber':
-					return await parsePhoneNumberHandler(request);
-				case 'googleimagesearch':
-					return await googleImageSearch(request);
-				case 'cloudinaryupload':
-					return await uploadToCloudinary(request);
-				case 'getislamicprayertimingsday':
-					return await getIslamicPrayerTimingsDay(request);
-				case 'getislamicprayertimingsweek':
-					return await getIslamicPrayerTimingsWeek(request);
-				case 'getcurrentdatetime':
-					return await getCurrentDateTime(request);
-				case 'sendtextmessage':
-					return await sendTextMessage(request);
-				case 'sendwhatsappmessage':
-					return await sendWhatsAppMessage(request as any);
-				case 'sendwhatsappvoicemessage':
-					return await sendWhatsAppVoiceMessage(request as any);
-				case 'creategoogledocsfile':
-					return await createGoogleDocsFile(request);
-				case 'creategooglesheetsfile':
-					return await createGoogleSheetsFile(request);
-				case 'updategoogledocsfile':
-					return await updateGoogleDocsFile(request);
-				case 'updategooglesheetsfile':
-					return await updateGoogleSheetsFile(request);
-				case 'setgooglefilepermissions':
-					return await setGoogleFilePermissions(request);
-				case 'sendemail':
-					return await sendEmail(request);
-				case 'texttoaudio':
-					return await textToAudioFile(request);
-				case 'audiototextfile':
-					return await audioFileToText(request);
-				case 'viewanddescribewhatsappimage':
-					return await viewAndDescribeWhatsAppImage(request);
-				case 'listentowhatsappvoiceaudio':
-					return await listenToWhatsAppVoiceAudio(request);
-				case 'markwhatsappmessageread':
-					return await markWhatsAppMessageRead(request);
-				case 'sendwhatsapplocation':
-					return await sendWhatsAppLocation(request);
-				case 'requestwhatsapplocation':
-					return await requestWhatsAppLocation(request);
+                const processRequest = async (request: any) => {
+                        console.log({ functionName, request: request.body });
+                        switch (functionName) {
+                                case 'ipaddresslookup': {
+                                        const { IPAddressLookUp } = await import('../functions/ip/ip');
+                                        return await IPAddressLookUp(request);
+                                }
+                                case 'locationresolver': {
+                                        const { getLocationData } = await import('../functions/resolvers/location');
+                                        return await getLocationData(request);
+                                }
+                                case 'getwebsitescreenshot': {
+                                        const { getWebsiteScreenshot } = await import('../functions/screenshot/getWebsiteScreenshot');
+                                        return await getWebsiteScreenshot(request);
+                                }
+                                case 'googlewebsearch': {
+                                        const { searchGoogle } = await import('../functions/searchGoogle/googleWebSearch');
+                                        return await searchGoogle(request);
+                                }
+                                case 'gettodaysweather': {
+                                        const { fetchTodaysWeatherData } = await import('../functions/weather/todaysWeather');
+                                        return await fetchTodaysWeatherData(request);
+                                }
+                                case 'getweeklyforecast': {
+                                        const { fetchWeeklyWeatherData } = await import('../functions/weather/weeklyWeather');
+                                        return await fetchWeeklyWeatherData(request);
+                                }
+                                case 'getextendedweather': {
+                                        const { fetchExtendedWeather } = await import('../functions/weather/fetchExtendedWeather');
+                                        return await fetchExtendedWeather(request);
+                                }
+                                case 'googleaddressresolver': {
+                                        const { googleAddressResolver } = await import('../functions/resolvers/googleAddressResolver');
+                                        return await googleAddressResolver(request);
+                                }
+                                case 'parsephonenumber': {
+                                        const { parsePhoneNumberHandler } = await import('../functions/resolvers/phonenumber');
+                                        return await parsePhoneNumberHandler(request);
+                                }
+                                case 'googleimagesearch': {
+                                        const { googleImageSearch } = await import('../functions/searchGoogle/googleImageSearch');
+                                        return await googleImageSearch(request);
+                                }
+                                case 'cloudinaryupload': {
+                                        const { uploadToCloudinary } = await import('../functions/weather/uploaders/uploadToCloudinary');
+                                        return await uploadToCloudinary(request);
+                                }
+                                case 'getislamicprayertimingsday': {
+                                        const { getIslamicPrayerTimingsDay } = await import('../functions/islamicPrayerTimingsDay');
+                                        return await getIslamicPrayerTimingsDay(request);
+                                }
+                                case 'getislamicprayertimingsweek': {
+                                        const { getIslamicPrayerTimingsWeek } = await import('../functions/IslamicPrayerTimingsWeek');
+                                        return await getIslamicPrayerTimingsWeek(request);
+                                }
+                                case 'getcurrentdatetime': {
+                                        const { getCurrentDateTime } = await import('./getCurrentDateTime');
+                                        return await getCurrentDateTime(request);
+                                }
+                                case 'sendtextmessage': {
+                                        const { sendTextMessage } = await import('../functions/communication/sendTextMessage');
+                                        return await sendTextMessage(request);
+                                }
+                                case 'sendwhatsappmessage': {
+                                        const { sendWhatsAppMessage } = await import('../functions/communication/sendWhatsAppMessage');
+                                        return await sendWhatsAppMessage(request as any);
+                                }
+                                case 'sendwhatsappvoicemessage': {
+                                        const { sendWhatsAppVoiceMessage } = await import('../functions/communication/sendWhatsAppVoiceMessage');
+                                        return await sendWhatsAppVoiceMessage(request as any);
+                                }
+                                case 'creategoogledocsfile': {
+                                        const { createGoogleDocsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+                                        return await createGoogleDocsFile(request);
+                                }
+                                case 'creategooglesheetsfile': {
+                                        const { createGoogleSheetsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+                                        return await createGoogleSheetsFile(request);
+                                }
+                                case 'updategoogledocsfile': {
+                                        const { updateGoogleDocsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+                                        return await updateGoogleDocsFile(request);
+                                }
+                                case 'updategooglesheetsfile': {
+                                        const { updateGoogleSheetsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+                                        return await updateGoogleSheetsFile(request);
+                                }
+                                case 'setgooglefilepermissions': {
+                                        const { setGoogleFilePermissions } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+                                        return await setGoogleFilePermissions(request);
+                                }
+                                case 'sendemail': {
+                                        const { sendEmail } = await import('../functions/communication/sendEmail');
+                                        return await sendEmail(request);
+                                }
+                                case 'texttoaudio': {
+                                        const { textToAudioFile } = await import('../functions/communication/textToAudio');
+                                        return await textToAudioFile(request);
+                                }
+                                case 'audiototextfile': {
+                                        const { audioFileToText } = await import('../functions/communication/audioToTextFile');
+                                        return await audioFileToText(request);
+                                }
+                                case 'viewanddescribewhatsappimage': {
+                                        const { viewAndDescribeWhatsAppImage } = await import('../functions/communication/viewAndDescribeWhatsAppImage');
+                                        return await viewAndDescribeWhatsAppImage(request);
+                                }
+                                case 'listentowhatsappvoiceaudio': {
+                                        const { listenToWhatsAppVoiceAudio } = await import('../functions/communication/listenToWhatsAppVoiceAudio');
+                                        return await listenToWhatsAppVoiceAudio(request);
+                                }
+                                case 'markwhatsappmessageread': {
+                                        const { markWhatsAppMessageRead } = await import('../functions/communication/markWhatsAppMessageRead');
+                                        return await markWhatsAppMessageRead(request);
+                                }
+                                case 'sendwhatsapplocation': {
+                                        const { sendWhatsAppLocation } = await import('../functions/communication/sendWhatsAppLocation');
+                                        return await sendWhatsAppLocation(request);
+                                }
+                                case 'requestwhatsapplocation': {
+                                        const { requestWhatsAppLocation } = await import('../functions/communication/requestWhatsAppLocation');
+                                        return await requestWhatsAppLocation(request);
+                                }
 
 				default:
 					throw new Error('Invalid function name.');

--- a/public/app.js
+++ b/public/app.js
@@ -54,7 +54,7 @@ window.onclick = (event) => {
 
 const fetchTools = async () => {
     try {
-        const res = await fetch('/api/toolsHandler', { method: 'OPTIONS' });
+        const res = await fetch('/belt', { method: 'OPTIONS' });
 
         const data = await res.json();
         tools = data.tools || [];


### PR DESCRIPTION
## Summary
- update tools fetch URL in `public/app.js`
- lazy-load handlers in `api/toolsHandler.ts` so loading the homepage only imports the tool list

## Testing
- `npm test` *(fails: no tests)*
- `npm run lint` *(fails: missing eslint module)*

------
https://chatgpt.com/codex/tasks/task_b_68511a9bb0c083249d548da721df71ba