### PR TITLE
Fix Node version for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": "20.x"
   },
   "scripts": {
     "build": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc && mkdir -p public",


### PR DESCRIPTION
## Summary
- pin Node.js version to 20.x in package.json

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_68511eb278708324a5887399190600b5