### PR TITLE
Add ESC key to close modal

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -52,6 +52,13 @@ window.onclick = (event) => {
     }
 };
 
+// Close modal when Escape key is pressed
+window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+        closeModal();
+    }
+});
+
 const fetchTools = async () => {
     try {
         const res = await fetch('/belt', { method: 'OPTIONS' });


### PR DESCRIPTION
## Summary
- close modal on Escape key press in the UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6851201f2210832495b54fb722ced8a8