### PR TITLE
Add URL slug helper for screenshot filenames

### DIFF
--- a/functions/screenshot/getWebsiteScreenshot.ts
+++ b/functions/screenshot/getWebsiteScreenshot.ts
@@ -3,6 +3,7 @@ import puppeteer from 'puppeteer-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import { VercelRequest } from '@vercel/node';
 import { uploadGDriveHelper } from '../../utils/getToken';
+import { sanitizeFilename } from '../../utils/sanitizeFilename';
 
 puppeteer.use(StealthPlugin());
 
@@ -104,11 +105,12 @@ export const getWebsiteScreenshot = async (request: VercelRequest) => {
 			await browser.close();
 
 			// Create FormData and append the screenshot buffer
-			const form = new FormData();
-			form.append('file', screenshotBuffer, {
-				contentType: 'image/png',
-			});
-			form.append('fileName', `screenshot-${url}.png`);
+                        const form = new FormData();
+                        form.append('file', screenshotBuffer, {
+                                contentType: 'image/png',
+                        });
+                        const safeName = sanitizeFilename(url);
+                        form.append('fileName', `screenshot-${safeName}.png`);
 			form.append('setPublic', 'true');
 			form.append('reUpload', 'true');
 

--- a/utils/sanitizeFilename.ts
+++ b/utils/sanitizeFilename.ts
@@ -1,0 +1,8 @@
+export const sanitizeFilename = (url: string): string => {
+        return url
+                .replace(/^https?:\/\//, '')
+                .replace(/[^a-z0-9]/gi, '-')
+                .replace(/-+/g, '-')
+                .replace(/^-|-$/g, '')
+                .toLowerCase();
+};


### PR DESCRIPTION
## Summary
- add `sanitizeFilename` helper to slugify URLs
- use `sanitizeFilename` in `getWebsiteScreenshot` when setting the `fileName`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68512069ac1c8324a587b99a96206c7a