### PR TITLE
Refactor tools handler using handler map

### DIFF
--- a/api/toolsHandler.ts
+++ b/api/toolsHandler.ts
@@ -1,6 +1,7 @@
 // Communication functions
 import { handleToolOptions } from '../functions/handleToolOptions';
 import { verifyRequestToken } from '../utils/verifyJWT';
+import { toolsMap } from "./toolsMap";
 
 interface AIRequest {
 	functionName: string;
@@ -24,134 +25,15 @@ const handler = async (request: any, response: any) => {
 			throw new Error('Invalid request method');
 		}
 
-		const processRequest = async (request: any) => {
-			console.log({ functionName, request: request.body });
-			switch (functionName) {
-				case 'ipaddresslookup': {
-					const { IPAddressLookUp } = await import('../functions/ip/ip');
-					return await IPAddressLookUp(request);
-				}
-				case 'locationresolver': {
-					const { getLocationData } = await import('../functions/resolvers/location');
-					return await getLocationData(request);
-				}
-				case 'getwebsitescreenshot': {
-					const { getWebsiteScreenshot } = await import('../functions/screenshot/getWebsiteScreenshot');
-					return await getWebsiteScreenshot(request);
-				}
-				case 'googlewebsearch': {
-					const { searchGoogle } = await import('../functions/searchGoogle/googleWebSearch');
-					return await searchGoogle(request);
-				}
-				case 'gettodaysweather': {
-					const { fetchTodaysWeatherData } = await import('../functions/weather/todaysWeather');
-					return await fetchTodaysWeatherData(request);
-				}
-				case 'getweeklyforecast': {
-					const { fetchWeeklyWeatherData } = await import('../functions/weather/weeklyWeather');
-					return await fetchWeeklyWeatherData(request);
-				}
-				case 'getextendedweather': {
-					const { fetchExtendedWeather } = await import('../functions/weather/fetchExtendedWeather');
-					return await fetchExtendedWeather(request);
-				}
-				case 'googleaddressresolver': {
-					const { googleAddressResolver } = await import('../functions/resolvers/googleAddressResolver');
-					return await googleAddressResolver(request);
-				}
-				case 'parsephonenumber': {
-					const { parsePhoneNumberHandler } = await import('../functions/resolvers/phonenumber');
-					return await parsePhoneNumberHandler(request);
-				}
-				case 'googleimagesearch': {
-					const { googleImageSearch } = await import('../functions/searchGoogle/googleImageSearch');
-					return await googleImageSearch(request);
-				}
-				case 'cloudinaryupload': {
-					const { uploadToCloudinary } = await import('../functions/weather/uploaders/uploadToCloudinary');
-					return await uploadToCloudinary(request);
-				}
-				case 'getislamicprayertimingsday': {
-					const { getIslamicPrayerTimingsDay } = await import('../functions/islamicPrayerTimingsDay');
-					return await getIslamicPrayerTimingsDay(request);
-				}
-				case 'getislamicprayertimingsweek': {
-					const { getIslamicPrayerTimingsWeek } = await import('../functions/IslamicPrayerTimingsWeek');
-					return await getIslamicPrayerTimingsWeek(request);
-				}
-				case 'getcurrentdatetime': {
-					const { getCurrentDateTime } = await import('./getCurrentDateTime');
-					return await getCurrentDateTime(request);
-				}
-				case 'sendtextmessage': {
-					const { sendTextMessage } = await import('../functions/communication/sendTextMessage');
-					return await sendTextMessage(request);
-				}
-				case 'sendwhatsappmessage': {
-					const { sendWhatsAppMessage } = await import('../functions/communication/sendWhatsAppMessage');
-					return await sendWhatsAppMessage(request as any);
-				}
-				case 'sendwhatsappvoicemessage': {
-					const { sendWhatsAppVoiceMessage } = await import('../functions/communication/sendWhatsAppVoiceMessage');
-					return await sendWhatsAppVoiceMessage(request as any);
-				}
-				case 'creategoogledocsfile': {
-					const { createGoogleDocsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
-					return await createGoogleDocsFile(request);
-				}
-				case 'creategooglesheetsfile': {
-					const { createGoogleSheetsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
-					return await createGoogleSheetsFile(request);
-				}
-				case 'updategoogledocsfile': {
-					const { updateGoogleDocsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
-					return await updateGoogleDocsFile(request);
-				}
-				case 'updategooglesheetsfile': {
-					const { updateGoogleSheetsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
-					return await updateGoogleSheetsFile(request);
-				}
-				case 'setgooglefilepermissions': {
-					const { setGoogleFilePermissions } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
-					return await setGoogleFilePermissions(request);
-				}
-				case 'sendemail': {
-					const { sendEmail } = await import('../functions/communication/sendEmail');
-					return await sendEmail(request);
-				}
-				case 'texttoaudio': {
-					const { textToAudioFile } = await import('../functions/communication/textToAudio');
-					return await textToAudioFile(request);
-				}
-				case 'audiototextfile': {
-					const { audioFileToText } = await import('../functions/communication/audioToTextFile');
-					return await audioFileToText(request);
-				}
-				case 'viewanddescribewhatsappimage': {
-					const { viewAndDescribeWhatsAppImage } = await import('../functions/communication/viewAndDescribeWhatsAppImage');
-					return await viewAndDescribeWhatsAppImage(request);
-				}
-				case 'listentowhatsappvoiceaudio': {
-					const { listenToWhatsAppVoiceAudio } = await import('../functions/communication/listenToWhatsAppVoiceAudio');
-					return await listenToWhatsAppVoiceAudio(request);
-				}
-				case 'markwhatsappmessageread': {
-					const { markWhatsAppMessageRead } = await import('../functions/communication/markWhatsAppMessageRead');
-					return await markWhatsAppMessageRead(request);
-				}
-				case 'sendwhatsapplocation': {
-					const { sendWhatsAppLocation } = await import('../functions/communication/sendWhatsAppLocation');
-					return await sendWhatsAppLocation(request);
-				}
-				case 'requestwhatsapplocation': {
-					const { requestWhatsAppLocation } = await import('../functions/communication/requestWhatsAppLocation');
-					return await requestWhatsAppLocation(request);
-				}
+                const processRequest = async (req: any) => {
+                        console.log({ functionName, request: req.body });
+                        const handler = toolsMap[functionName as string];
+                        if (!handler) {
+                                throw new Error("Invalid function name.");
+                        }
+                        return await handler(req);
+                };
 
-				default:
-					throw new Error('Invalid function name.');
-			}
-		};
 
 		const responseData = await processRequest(request);
 		response.status(200).json(responseData);

--- a/api/toolsMap.ts
+++ b/api/toolsMap.ts
@@ -1,0 +1,124 @@
+export type ToolHandler = (req: any) => Promise<any>;
+
+export const toolsMap: Record<string, ToolHandler> = {
+  ipaddresslookup: async (req) => {
+    const { IPAddressLookUp } = await import('../functions/ip/ip');
+    return IPAddressLookUp(req);
+  },
+  locationresolver: async (req) => {
+    const { getLocationData } = await import('../functions/resolvers/location');
+    return getLocationData(req);
+  },
+  getwebsitescreenshot: async (req) => {
+    const { getWebsiteScreenshot } = await import('../functions/screenshot/getWebsiteScreenshot');
+    return getWebsiteScreenshot(req);
+  },
+  googlewebsearch: async (req) => {
+    const { searchGoogle } = await import('../functions/searchGoogle/googleWebSearch');
+    return searchGoogle(req);
+  },
+  gettodaysweather: async (req) => {
+    const { fetchTodaysWeatherData } = await import('../functions/weather/todaysWeather');
+    return fetchTodaysWeatherData(req);
+  },
+  getweeklyforecast: async (req) => {
+    const { fetchWeeklyWeatherData } = await import('../functions/weather/weeklyWeather');
+    return fetchWeeklyWeatherData(req);
+  },
+  getextendedweather: async (req) => {
+    const { fetchExtendedWeather } = await import('../functions/weather/fetchExtendedWeather');
+    return fetchExtendedWeather(req);
+  },
+  googleaddressresolver: async (req) => {
+    const { googleAddressResolver } = await import('../functions/resolvers/googleAddressResolver');
+    return googleAddressResolver(req);
+  },
+  parsephonenumber: async (req) => {
+    const { parsePhoneNumberHandler } = await import('../functions/resolvers/phonenumber');
+    return parsePhoneNumberHandler(req);
+  },
+  googleimagesearch: async (req) => {
+    const { googleImageSearch } = await import('../functions/searchGoogle/googleImageSearch');
+    return googleImageSearch(req);
+  },
+  cloudinaryupload: async (req) => {
+    const { uploadToCloudinary } = await import('../functions/weather/uploaders/uploadToCloudinary');
+    return uploadToCloudinary(req);
+  },
+  getislamicprayertimingsday: async (req) => {
+    const { getIslamicPrayerTimingsDay } = await import('../functions/islamicPrayerTimingsDay');
+    return getIslamicPrayerTimingsDay(req);
+  },
+  getislamicprayertimingsweek: async (req) => {
+    const { getIslamicPrayerTimingsWeek } = await import('../functions/IslamicPrayerTimingsWeek');
+    return getIslamicPrayerTimingsWeek(req);
+  },
+  getcurrentdatetime: async (req) => {
+    const { getCurrentDateTime } = await import('./getCurrentDateTime');
+    return getCurrentDateTime(req);
+  },
+  sendtextmessage: async (req) => {
+    const { sendTextMessage } = await import('../functions/communication/sendTextMessage');
+    return sendTextMessage(req);
+  },
+  sendwhatsappmessage: async (req) => {
+    const { sendWhatsAppMessage } = await import('../functions/communication/sendWhatsAppMessage');
+    return sendWhatsAppMessage(req as any);
+  },
+  sendwhatsappvoicemessage: async (req) => {
+    const { sendWhatsAppVoiceMessage } = await import('../functions/communication/sendWhatsAppVoiceMessage');
+    return sendWhatsAppVoiceMessage(req as any);
+  },
+  creategoogledocsfile: async (req) => {
+    const { createGoogleDocsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+    return createGoogleDocsFile(req);
+  },
+  creategooglesheetsfile: async (req) => {
+    const { createGoogleSheetsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+    return createGoogleSheetsFile(req);
+  },
+  updategoogledocsfile: async (req) => {
+    const { updateGoogleDocsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+    return updateGoogleDocsFile(req);
+  },
+  updategooglesheetsfile: async (req) => {
+    const { updateGoogleSheetsFile } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+    return updateGoogleSheetsFile(req);
+  },
+  setgooglefilepermissions: async (req) => {
+    const { setGoogleFilePermissions } = await import('../functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc');
+    return setGoogleFilePermissions(req);
+  },
+  sendemail: async (req) => {
+    const { sendEmail } = await import('../functions/communication/sendEmail');
+    return sendEmail(req);
+  },
+  texttoaudio: async (req) => {
+    const { textToAudioFile } = await import('../functions/communication/textToAudio');
+    return textToAudioFile(req);
+  },
+  audiototextfile: async (req) => {
+    const { audioFileToText } = await import('../functions/communication/audioToTextFile');
+    return audioFileToText(req);
+  },
+  viewanddescribewhatsappimage: async (req) => {
+    const { viewAndDescribeWhatsAppImage } = await import('../functions/communication/viewAndDescribeWhatsAppImage');
+    return viewAndDescribeWhatsAppImage(req);
+  },
+  listentowhatsappvoiceaudio: async (req) => {
+    const { listenToWhatsAppVoiceAudio } = await import('../functions/communication/listenToWhatsAppVoiceAudio');
+    return listenToWhatsAppVoiceAudio(req);
+  },
+  markwhatsappmessageread: async (req) => {
+    const { markWhatsAppMessageRead } = await import('../functions/communication/markWhatsAppMessageRead');
+    return markWhatsAppMessageRead(req);
+  },
+  sendwhatsapplocation: async (req) => {
+    const { sendWhatsAppLocation } = await import('../functions/communication/sendWhatsAppLocation');
+    return sendWhatsAppLocation(req);
+  },
+  requestwhatsapplocation: async (req) => {
+    const { requestWhatsAppLocation } = await import('../functions/communication/requestWhatsAppLocation');
+    return requestWhatsAppLocation(req);
+  },
+};


### PR DESCRIPTION
## Summary
- map tool names to async handlers
- use the map instead of a `switch` in the tools API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685122af3e6c832488f9d176e77cb44f