### PR TITLE
Use single OPEN_WEATHER_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,8 @@
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key
 
-# OpenWeather Map (supports key rotation)
-OPEN_WEATHER_API_KEY_1=weather-key-1
-OPEN_WEATHER_API_KEY_2=weather-key-2
+# OpenWeather Map
+OPEN_WEATHER_API_KEY=your-openweather-api-key
 
 # MongoDB
 DB_USERNAME=your-mongo-username

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The project relies on several environment variables. Below is a list of all of t
 - `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_ASSISTANT_PHONE_NUMBER` – Twilio credentials for sending SMS messages.
 - `GMAIL_MAILER_ASSISTANT_NAME` – display name used when sending email via Gmail.
 - `GOOGLE_API_KEY` – API key used for geocoding and Google search utilities.
-- `OPEN_WEATHER_API_KEY_1`, `OPEN_WEATHER_API_KEY_2`, ... – OpenWeatherMap API keys. Multiple keys can be set for rotation.
+- `OPEN_WEATHER_API_KEY` – OpenWeatherMap API key used for location and weather lookups.
 - `JWT_SECRET`
 
 

--- a/functions/resolvers/resolveLocation.ts
+++ b/functions/resolvers/resolveLocation.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import gps2zip from 'gps2zip';
-import { getNextEnvKey } from 'envholster';
 import { connectToMongo } from '../../utils/mongo';
 import { LocationInput, LocationOutput } from './locationTypes';
 import { getStateAbbreviation } from '../../utils/getStateAbbreviation';
@@ -17,9 +16,7 @@ const fetchCoordinates = async (url: string) => {
 };
 
 const getCoordinatesByAddress = async ({ city, state, country }: { city: string; state?: string; country: string }): Promise<any> => {
-	const { key: apiKey } = await getNextEnvKey({
-		baseEnvName: 'OPEN_WEATHER_API_KEY_',
-	});
+        const apiKey = process.env.OPEN_WEATHER_API_KEY;
 
 	const encodedCity = encodeURIComponent(city);
 	const encodedState = state ? encodeURIComponent(state) : '';
@@ -39,9 +36,7 @@ const getCoordinatesByAddress = async ({ city, state, country }: { city: string;
 };
 
 const getCoordinatesByZipCode = async (zipCode: string): Promise<any> => {
-	const { key: apiKey } = await getNextEnvKey({
-		baseEnvName: 'OPEN_WEATHER_API_KEY_',
-	});
+        const apiKey = process.env.OPEN_WEATHER_API_KEY;
 
 	const apiUrl = `https://api.openweathermap.org/geo/1.0/zip?zip=${zipCode}&appid=${apiKey}`;
 	const data = await fetchCoordinates(apiUrl);
@@ -55,9 +50,7 @@ const getCoordinatesByZipCode = async (zipCode: string): Promise<any> => {
 };
 
 const getAddressByCoordinates = async (lat: number, lon: number): Promise<any> => {
-	const { key: apiKey } = await getNextEnvKey({
-		baseEnvName: 'OPEN_WEATHER_API_KEY_',
-	});
+        const apiKey = process.env.OPEN_WEATHER_API_KEY;
 
 	const apiUrl = `https://api.openweathermap.org/geo/1.0/reverse?lat=${lat}&lon=${lon}&limit=1&appid=${apiKey}`;
 

--- a/functions/weather/openWeatherFunction.ts
+++ b/functions/weather/openWeatherFunction.ts
@@ -1,12 +1,9 @@
 import axios from 'axios';
-import { getNextEnvKey } from 'envholster';
 import { LocationOutput } from '../resolvers/locationTypes';
 import { resolveLocation } from '../resolvers/resolveLocation';
 
 const fetchWeatherData = async ({ lat, lon, zipCode }: { lat?: number; lon?: number; zipCode?: string }) => {
-	const { key: weatherApiKey } = await getNextEnvKey({
-		baseEnvName: 'OPEN_WEATHER_API_KEY_',
-	});
+        const weatherApiKey = process.env.OPEN_WEATHER_API_KEY;
 
 	let forecastApiUrl: string;
 


### PR DESCRIPTION
## Summary
- use `process.env.OPEN_WEATHER_API_KEY` instead of envholster rotation
- update `.env.example` for the new variable
- document the change in README

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run build` *(fails: Cannot find module 'typescript/bin/tsc')*

------
https://chatgpt.com/codex/tasks/task_b_685123eef328832492ba10bcbad0189f