### PR TITLE
Use single ScaleSERP key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,6 @@ GMAIL_MAILER_ASSISTANT_NAME=Assistant
 # Google API
 GOOGLE_API_KEY=your-google-api-key
 
+# Scale SERP API
+SCALE_SERP_API_KEY=your-scale-serp-key
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The project relies on several environment variables. Below is a list of all of t
 - `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_ASSISTANT_PHONE_NUMBER` – Twilio credentials for sending SMS messages.
 - `GMAIL_MAILER_ASSISTANT_NAME` – display name used when sending email via Gmail.
 - `GOOGLE_API_KEY` – API key used for geocoding and Google search utilities.
+- `SCALE_SERP_API_KEY` – API key used for web search requests through ScaleSERP.
 - `OPEN_WEATHER_API_KEY_1`, `OPEN_WEATHER_API_KEY_2`, ... – OpenWeatherMap API keys. Multiple keys can be set for rotation.
 - `JWT_SECRET`
 

--- a/functions/searchGoogle/googleWebSearch.ts
+++ b/functions/searchGoogle/googleWebSearch.ts
@@ -1,12 +1,14 @@
 import axios from 'axios';
-import { getNextEnvKey } from 'envholster';
 import { parseQueryParams } from '../../utils/parseQueryParams';
 import { SerpSearchRequest, WebSearchResponse, WebSearchResult } from './searchGoogleTypes';
 import { VercelRequest } from '@vercel/node';
 
 export const searchGoogle = async (request: VercelRequest): Promise<WebSearchResponse> => {
-	try {
-		const { key: apiKey } = await getNextEnvKey({ baseEnvName: 'SCALE_SERP_API_KEY_' });
+       try {
+               const apiKey = process.env.SCALE_SERP_API_KEY;
+               if (!apiKey) {
+                       throw new Error('SCALE_SERP_API_KEY environment variable is not set');
+               }
 
 		let requests: SerpSearchRequest[];
 


### PR DESCRIPTION
## Summary
- use SCALE_SERP_API_KEY directly in googleWebSearch
- document SCALE_SERP_API_KEY in README and `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685123f04afc8324a5cc03fbd9f7aea1