### PR TITLE
Refactor JWT token config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,8 @@ DB_CLUSTER=your-db-cluster
 # Google Drive
 GDRIVE_SERVICE_ACCOUNT_JSON={"client_email":"example@project.iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"}
 
-# Trusted API keys
-TRUSTED_API_KEY_1=api-key-1
-TRUSTED_API_KEY_2=api-key-2
+# Trusted API key
+TRUSTED_API_KEY=api-key
 JWT_SECRET=your-jwt-secret
 
 # Cloudinary

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a complete list of available tools and their descriptions, visit the [homepa
 
 ## 🔐 JWT Authentication
 
-All API calls require an `Authorization` header containing a valid JWT. Tokens can be generated using the helper `getToken()` which relies on the `TRUSTED_API_KEY_1` and `TRUSTED_API_KEY_2` environment variables. Incoming tokens are verified using the `JWT_SECRET` environment variable.
+All API calls require an `Authorization` header containing a valid JWT. Tokens can be generated using the helper `getToken()` which relies on the `TRUSTED_API_KEY` environment variable. Incoming tokens are verified using the `JWT_SECRET` environment variable.
 
 ```bash
 Authorization: Bearer <your-jwt-token>
@@ -45,7 +45,7 @@ The project relies on several environment variables. Below is a list of all of t
 - `OPENAI_API_KEY` – token used to call the OpenAI API.
 - `DB_USERNAME`, `DB_PASSWORD`, `DB_NAME`, `DB_CLUSTER` – MongoDB connection details.
 - `GDRIVE_SERVICE_ACCOUNT_JSON` – JSON credentials for the Google Drive service account.
-- `TRUSTED_API_KEY_1`, `TRUSTED_API_KEY_2` – secrets used to sign and verify JWT tokens.
+ - `TRUSTED_API_KEY` – secret used to sign and verify JWT tokens.
 - `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET` – Cloudinary configuration for uploading media (screenshots, audio, etc.).
 - `AZURE_SPEECH_KEY`, `AZURE_SPEECH_REGION` – Azure Speech service credentials for text‑to‑speech features.
 - `WHATSAPP_GRAPH_API_TOKEN`, `WHATSAPP_GRAPH_API_URL`, `WHATSAPP_ASSISTANT_PHONE_NUMBER` – credentials and configuration for the WhatsApp Business API.

--- a/utils/getToken.ts
+++ b/utils/getToken.ts
@@ -5,8 +5,7 @@ import { Collection } from 'mongodb';
 import { connectToMongo } from './mongo';
 
 const tokenUrl = 'https://jwt.aquataze.com/';
-const apiKey1 = process.env.TRUSTED_API_KEY_1 || '';
-const apiKey2 = process.env.TRUSTED_API_KEY_2 || '';
+const apiKey = process.env.TRUSTED_API_KEY || '';
 const tokenFilePath = path.resolve(__dirname, 'token.json');
 
 
@@ -34,18 +33,17 @@ const getTokenCollection = async (): Promise<Collection> => {
 
 const fetchToken = async (): Promise<TokenStore> => {
 	try {
-		const response = await axios.post<TokenResponse>(
-			tokenUrl,
-			{
-				apiKey1: apiKey1,
-				apiKey2: apiKey2,
-			},
-			{
-				headers: {
-					'Content-Type': 'application/json',
-				},
-			}
-		);
+                const response = await axios.post<TokenResponse>(
+                        tokenUrl,
+                        {
+                                apiKey: apiKey,
+                        },
+                        {
+                                headers: {
+                                        'Content-Type': 'application/json',
+                                },
+                        }
+                );
 
 		const tokenData = response.data;
 		return {


### PR DESCRIPTION
## Summary
- use single `TRUSTED_API_KEY` for token requests
- document updated env variable in README and `.env.example`

## Testing
- `npm test`
- `npm run lint` *(fails: numerous prettier errors)*

------
https://chatgpt.com/codex/tasks/task_b_685123f67f748324b8091c850b046c68