### PR TITLE
Improve JWT verification

### DIFF
--- a/api/toolsHandler.ts
+++ b/api/toolsHandler.ts
@@ -9,12 +9,13 @@ interface AIRequest {
 }
 
 const handler = async (request: any, response: any) => {
-	if (request.method === 'OPTIONS') {
-		return await handleToolOptions(response);
-	}
-	if (!verifyRequestToken(request)) {
-		return response.status(401).json({ error: 'Unauthorized' });
-	}
+        if (request.method === 'OPTIONS') {
+                return await handleToolOptions(response);
+        }
+        const verification = verifyRequestToken(request);
+        if (!verification.valid) {
+                return response.status(401).json({ error: verification.error });
+        }
 	try {
 		let functionName: string | null = null;
 

--- a/api/welcome.ts
+++ b/api/welcome.ts
@@ -4,9 +4,10 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { verifyRequestToken } from '../utils/verifyJWT';
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
-	if (!verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        const verification = verifyRequestToken(request);
+        if (!verification.valid) {
+                return response.status(401).json({ status: false, message: verification.error });
+        }
 	try {
 		const filePath = path.join(process.cwd(), 'public', 'index.html');
 		const htmlContent = fs.readFileSync(filePath, 'utf8');

--- a/otherServerlessAPI/area.ts
+++ b/otherServerlessAPI/area.ts
@@ -26,9 +26,12 @@ const convertArea = ({ from, to, value }: { from: string; to: string; value: num
 };
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
-	if (request.method !== 'OPTIONS' && !verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        if (request.method !== 'OPTIONS') {
+                const verification = verifyRequestToken(request);
+                if (!verification.valid) {
+                        return response.status(401).json({ status: false, message: verification.error });
+                }
+        }
 	try {
 		let requests: any[] = [];
 

--- a/otherServerlessAPI/fetchTextContentOfWebsite.ts
+++ b/otherServerlessAPI/fetchTextContentOfWebsite.ts
@@ -29,9 +29,10 @@ const handler = async (request: VercelRequest, response: VercelResponse) => {
 
 		return response.status(200).json(interfaceDescription);
 	}
-	if (!verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        const verification = verifyRequestToken(request);
+        if (!verification.valid) {
+                return response.status(401).json({ status: false, message: verification.error });
+        }
 
 	try {
 		let requests: ScrapeRequestBody[];

--- a/otherServerlessAPI/landing.ts
+++ b/otherServerlessAPI/landing.ts
@@ -72,9 +72,10 @@ const handler = async (request: VercelRequest, response: VercelResponse) => {
 
 		return response.status(200).json(interfaceDescription);
 	}
-	if (!verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        const verification = verifyRequestToken(request);
+        if (!verification.valid) {
+                return response.status(401).json({ status: false, message: verification.error });
+        }
 
 	try {
 		let requests: ScrapeRequestBody[];

--- a/otherServerlessAPI/length.ts
+++ b/otherServerlessAPI/length.ts
@@ -26,9 +26,12 @@ const convertLength = ({ from, to, value }: { from: string; to: string; value: n
 };
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
-	if (request.method !== 'OPTIONS' && !verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        if (request.method !== 'OPTIONS') {
+                const verification = verifyRequestToken(request);
+                if (!verification.valid) {
+                        return response.status(401).json({ status: false, message: verification.error });
+                }
+        }
 	try {
 		let requests: any[] = [];
 

--- a/otherServerlessAPI/speed.ts
+++ b/otherServerlessAPI/speed.ts
@@ -59,9 +59,12 @@ const convertSpeed = ({ from, to, value }: { from: string; to: string; value: nu
 };
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
-	if (request.method !== 'OPTIONS' && !verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        if (request.method !== 'OPTIONS') {
+                const verification = verifyRequestToken(request);
+                if (!verification.valid) {
+                        return response.status(401).json({ status: false, message: verification.error });
+                }
+        }
 	try {
 		let requests: any[] = [];
 

--- a/otherServerlessAPI/temperature.ts
+++ b/otherServerlessAPI/temperature.ts
@@ -32,9 +32,12 @@ const convertTemperature = ({ from, to, value }: { from: string; to: string; val
 };
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
-	if (request.method !== 'OPTIONS' && !verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        if (request.method !== 'OPTIONS') {
+                const verification = verifyRequestToken(request);
+                if (!verification.valid) {
+                        return response.status(401).json({ status: false, message: verification.error });
+                }
+        }
 	try {
 		let requests: any[] = [];
 

--- a/otherServerlessAPI/volume.ts
+++ b/otherServerlessAPI/volume.ts
@@ -26,9 +26,12 @@ const convertVolume = ({ from, to, value }: { from: string; to: string; value: n
 };
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
-	if (request.method !== 'OPTIONS' && !verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        if (request.method !== 'OPTIONS') {
+                const verification = verifyRequestToken(request);
+                if (!verification.valid) {
+                        return response.status(401).json({ status: false, message: verification.error });
+                }
+        }
 	try {
 		let requests: any[] = [];
 

--- a/otherServerlessAPI/weight.ts
+++ b/otherServerlessAPI/weight.ts
@@ -26,9 +26,12 @@ const convertWeight = ({ from, to, value }: { from: string; to: string; value: n
 };
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
-	if (request.method !== 'OPTIONS' && !verifyRequestToken(request)) {
-		return response.status(401).json({ status: false, message: 'Unauthorized' });
-	}
+        if (request.method !== 'OPTIONS') {
+                const verification = verifyRequestToken(request);
+                if (!verification.valid) {
+                        return response.status(401).json({ status: false, message: verification.error });
+                }
+        }
 	try {
 		let requests: any[] = [];
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc && mkdir -p public",
-    "test": "echo \"No tests\"",
+    "test": "npm run build && node tests/verifyJWT.test.js",
     "lint": "ESLINT_USE_FLAT_CONFIG=true eslint \"**/*.ts\"",
     "format": "prettier --write \"**/*.ts\""
   },

--- a/tests/verifyJWT.test.js
+++ b/tests/verifyJWT.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const jwt = require('jsonwebtoken');
+const { verifyJWT } = require('../dist/utils/verifyJWT.js');
+
+process.env.JWT_SECRET = 'testsecret';
+
+const validToken = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET, {
+  algorithm: 'HS256',
+  expiresIn: '1h',
+});
+
+const expiredToken = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET, {
+  algorithm: 'HS256',
+  expiresIn: -10, // already expired
+});
+
+// Valid token
+assert.deepStrictEqual(verifyJWT('Bearer ' + validToken).valid, true);
+
+// Expired token
+const expiredResult = verifyJWT('Bearer ' + expiredToken);
+assert.strictEqual(expiredResult.valid, false);
+assert.strictEqual(expiredResult.error, 'expired');
+
+// Malformed token
+const malformedResult = verifyJWT('Bearer malformed');
+assert.strictEqual(malformedResult.valid, false);
+assert.strictEqual(malformedResult.error, 'malformed');
+
+console.log('All tests passed');

--- a/utils/verifyJWT.ts
+++ b/utils/verifyJWT.ts
@@ -1,28 +1,43 @@
-import jwt from 'jsonwebtoken';
+import jwt, { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import type { VercelRequest } from '@vercel/node';
+
+export type JWTVerificationResult =
+  | { valid: true; payload: any }
+  | { valid: false; error: 'expired' | 'malformed' | 'invalid' };
 
 /**
  * Verify the JWT from an Authorization header.
- * Returns true if valid, false otherwise.
+ * Returns a result describing whether the token is valid and, if not,
+ * the reason why.
  */
-export function verifyJWT(authorizationHeader?: string): boolean {
-	const secret = process.env.JWT_SECRET;
-	if (!secret || !authorizationHeader) {
-		return false;
-	}
-	const token = authorizationHeader.split(' ')[1];
-	try {
-		jwt.verify(token, secret);
-		return true;
-	} catch {
-		return false;
-	}
+export function verifyJWT(authorizationHeader?: string): JWTVerificationResult {
+        const secret = process.env.JWT_SECRET;
+        if (!secret || !authorizationHeader) {
+                return { valid: false, error: 'invalid' };
+        }
+        const token = authorizationHeader.split(' ')[1];
+        try {
+                const payload = jwt.verify(token, secret, {
+                        algorithms: ['HS256'],
+                });
+                return { valid: true, payload };
+        } catch (err) {
+                if (err instanceof TokenExpiredError) {
+                        return { valid: false, error: 'expired' };
+                }
+                if (err instanceof JsonWebTokenError) {
+                        return { valid: false, error: 'malformed' };
+                }
+                return { valid: false, error: 'invalid' };
+        }
 }
 
 /**
  * Convenience helper to verify the token of a request object.
  */
-export function verifyRequestToken(request: VercelRequest | { headers: any }): boolean {
-	const header = request.headers?.authorization || request.headers?.Authorization;
-	return verifyJWT(typeof header === 'string' ? header : undefined);
+export function verifyRequestToken(
+  request: VercelRequest | { headers: any }
+): JWTVerificationResult {
+        const header = request.headers?.authorization || request.headers?.Authorization;
+        return verifyJWT(typeof header === 'string' ? header : undefined);
 }


### PR DESCRIPTION
## Summary
- add detailed JWT verification result
- handle verification errors in serverless handlers
- add unit tests for verifyJWT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68512a54e2008324ab4ab96803955a66