### PR TITLE
Add unit tests for utility modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc && mkdir -p public",
-    "test": "npm run build && node tests/verifyJWT.test.js",
+    "test": "npm run build && node tests/verifyJWT.test.js && node tests/getStateAbbreviation.test.js && node tests/encodeEmailContent.test.js && node tests/parseQueryParams.test.js",
     "lint": "ESLINT_USE_FLAT_CONFIG=true eslint \"**/*.ts\"",
     "format": "prettier --write \"**/*.ts\""
   },

--- a/tests/encodeEmailContent.test.js
+++ b/tests/encodeEmailContent.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { encodeEmailContent, EncodingType } = require('../dist/utils/encodeEmailContent.js');
+
+// Subject encoding
+const subjectResult = encodeEmailContent({ content: 'Hello', type: EncodingType.Subject });
+const expectedSubject = `=?utf-8?B?${Buffer.from('Hello', 'utf-8').toString('base64')}?=`;
+assert.strictEqual(subjectResult.isEncoded, true);
+assert.strictEqual(subjectResult.encodedContent, expectedSubject);
+
+// MIME message encoding
+const mimeResult = encodeEmailContent({ content: 'Hello', type: EncodingType.MimeMessage });
+const expectedMime = Buffer.from('Hello', 'utf-8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
+assert.strictEqual(mimeResult.encodedContent, expectedMime);
+
+// Attachment encoding of plain text
+const attachmentResult = encodeEmailContent({ content: 'file content', type: EncodingType.Attachment });
+const expectedAttachment = Buffer.from('file content', 'utf-8').toString('base64');
+assert.strictEqual(attachmentResult.encodedContent, expectedAttachment);
+
+// Attachment content already encoded
+const alreadyResult = encodeEmailContent({ content: expectedAttachment, type: EncodingType.Attachment });
+assert.strictEqual(alreadyResult.encodedContent, expectedAttachment);
+assert.strictEqual(alreadyResult.message, 'Attachment content was already Base64 encoded.');
+
+console.log('encodeEmailContent tests passed');

--- a/tests/getStateAbbreviation.test.js
+++ b/tests/getStateAbbreviation.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { getStateAbbreviation } = require('../dist/utils/getStateAbbreviation.js');
+
+assert.strictEqual(getStateAbbreviation('California'), 'CA');
+assert.strictEqual(getStateAbbreviation('ca'), 'CA');
+assert.strictEqual(getStateAbbreviation('Texas'), 'TX');
+assert.strictEqual(getStateAbbreviation('unknown'), 'UNKNOWN');
+
+console.log('getStateAbbreviation tests passed');

--- a/tests/parseQueryParams.test.js
+++ b/tests/parseQueryParams.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { parseQueryParams } = require('../dist/utils/parseQueryParams.js');
+
+const result = parseQueryParams({ page: '10', search: 'abc', active: true, score: '5.5', other: 'text' });
+assert.strictEqual(result.page, 10);
+assert.strictEqual(result.search, 'abc');
+assert.strictEqual(result.active, true);
+assert.strictEqual(result.score, 5.5);
+assert.strictEqual(result.other, 'text');
+
+console.log('parseQueryParams tests passed');


### PR DESCRIPTION
## Summary
- test `getStateAbbreviation`, `encodeEmailContent`, and `parseQueryParams`
- run all tests via updated npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68512ebaa3e88324863c98c4e424b615