### PR TITLE
Fix error status in getVisualWeather

### DIFF
--- a/functions/weather/visualWeatherFunction.ts
+++ b/functions/weather/visualWeatherFunction.ts
@@ -110,11 +110,11 @@ export const getVisualWeather = async (request: VercelRequest) => {
 				data: weatherData,
 			};
 		}
-	} catch (error: any) {
-		return {
-			status: true,
-			data: null,
-			error: error.message,
-		};
-	}
+        } catch (error: any) {
+                return {
+                        status: false,
+                        data: null,
+                        error: error.message,
+                };
+        }
 };


### PR DESCRIPTION
## Summary
- return `status: false` on errors in `visualWeatherFunction`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68512ef9668c83249d4a99722e9404a6