### PR TITLE
Add environment variable checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Create a `.env` file using `.env.example` as a reference. Required variables inc
 - `GOOGLE_API_KEY` – Key for Google APIs
 - `SCALE_SERP_API_KEY` – API key for Scale SERP web search
 
+These variables must be configured for the related features to work. Modules like
+`utils/getToken.ts` and `utils/mongo.ts` now throw errors when values such as
+`TRUSTED_API_KEY` or the MongoDB credentials are missing.
+
 ## Building and Deploying to Vercel
 
 1. Install dependencies with `npm install`.

--- a/functions/webTools/generateLandingPage.ts
+++ b/functions/webTools/generateLandingPage.ts
@@ -5,6 +5,10 @@ import { parseQueryParams } from '../../utils/parseQueryParams';
 
 const openaiApiKey = process.env.OPENAI_API_KEY;
 
+if (!openaiApiKey) {
+        throw new Error('OPENAI_API_KEY is not defined in environment variables.');
+}
+
 interface ScrapeRequestBody {
 	url: string;
 }

--- a/utils/getToken.ts
+++ b/utils/getToken.ts
@@ -6,6 +6,10 @@ import { connectToMongo } from './mongo';
 
 const tokenUrl = 'https://jwt.aquataze.com/';
 const apiKey = process.env.TRUSTED_API_KEY || '';
+
+if (!apiKey) {
+        throw new Error('TRUSTED_API_KEY is not defined in environment variables.');
+}
 const tokenFilePath = path.resolve(__dirname, 'token.json');
 
 const uploaderUrl = 'https://gdrive.aquataze.com/';

--- a/utils/mongo.ts
+++ b/utils/mongo.ts
@@ -2,6 +2,12 @@ import { MongoClient, Db, Collection } from 'mongodb';
 
 const { DB_USERNAME: dbUsername = '', DB_PASSWORD: dbPassword = '', DB_NAME: dbName = '', DB_CLUSTER: dbClusterName = '' } = process.env;
 
+if (!dbUsername || !dbPassword || !dbName || !dbClusterName) {
+        throw new Error(
+                'MongoDB credentials are missing. Please set DB_USERNAME, DB_PASSWORD, DB_NAME, and DB_CLUSTER.'
+        );
+}
+
 const uri = `mongodb+srv://${encodeURIComponent(dbUsername)}:${encodeURIComponent(dbPassword)}@${dbClusterName}/?retryWrites=true&w=majority`;
 
 let client: MongoClient | null = null;


### PR DESCRIPTION
## Summary
- throw errors when TRUSTED_API_KEY, MongoDB credentials or OPENAI_API_KEY are missing
- document the new env var requirements in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68513155fea08324bc652308f1ba7b1e