### PR TITLE
Refactor tests to Jest style

### DIFF
--- a/tests/encodeEmailContent.test.js
+++ b/tests/encodeEmailContent.test.js
@@ -1,25 +1,41 @@
-const assert = require('assert');
 const { encodeEmailContent, EncodingType } = require('../dist/utils/encodeEmailContent.js');
 
-// Subject encoding
-const subjectResult = encodeEmailContent({ content: 'Hello', type: EncodingType.Subject });
-const expectedSubject = `=?utf-8?B?${Buffer.from('Hello', 'utf-8').toString('base64')}?=`;
-assert.strictEqual(subjectResult.isEncoded, true);
-assert.strictEqual(subjectResult.encodedContent, expectedSubject);
+describe('encodeEmailContent', () => {
+  test('subject encoding', () => {
+    const subjectResult = encodeEmailContent({
+      content: 'Hello',
+      type: EncodingType.Subject,
+    });
+    const expectedSubject = `=?utf-8?B?${Buffer.from('Hello', 'utf-8').toString('base64')}?=`;
+    expect(subjectResult.isEncoded).toBe(true);
+    expect(subjectResult.encodedContent).toBe(expectedSubject);
+  });
 
-// MIME message encoding
-const mimeResult = encodeEmailContent({ content: 'Hello', type: EncodingType.MimeMessage });
-const expectedMime = Buffer.from('Hello', 'utf-8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
-assert.strictEqual(mimeResult.encodedContent, expectedMime);
+  test('MIME message encoding', () => {
+    const mimeResult = encodeEmailContent({
+      content: 'Hello',
+      type: EncodingType.MimeMessage,
+    });
+    const expectedMime = Buffer.from('Hello', 'utf-8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+    expect(mimeResult.encodedContent).toBe(expectedMime);
+  });
 
-// Attachment encoding of plain text
-const attachmentResult = encodeEmailContent({ content: 'file content', type: EncodingType.Attachment });
-const expectedAttachment = Buffer.from('file content', 'utf-8').toString('base64');
-assert.strictEqual(attachmentResult.encodedContent, expectedAttachment);
+  test('attachment encoding of plain text', () => {
+    const attachmentResult = encodeEmailContent({
+      content: 'file content',
+      type: EncodingType.Attachment,
+    });
+    const expectedAttachment = Buffer.from('file content', 'utf-8').toString('base64');
+    expect(attachmentResult.encodedContent).toBe(expectedAttachment);
 
-// Attachment content already encoded
-const alreadyResult = encodeEmailContent({ content: expectedAttachment, type: EncodingType.Attachment });
-assert.strictEqual(alreadyResult.encodedContent, expectedAttachment);
-assert.strictEqual(alreadyResult.message, 'Attachment content was already Base64 encoded.');
-
-console.log('encodeEmailContent tests passed');
+    const alreadyResult = encodeEmailContent({
+      content: expectedAttachment,
+      type: EncodingType.Attachment,
+    });
+    expect(alreadyResult.encodedContent).toBe(expectedAttachment);
+    expect(alreadyResult.message).toBe('Attachment content was already Base64 encoded.');
+  });
+});

--- a/tests/getStateAbbreviation.test.js
+++ b/tests/getStateAbbreviation.test.js
@@ -1,9 +1,13 @@
-const assert = require('assert');
 const { getStateAbbreviation } = require('../dist/utils/getStateAbbreviation.js');
 
-assert.strictEqual(getStateAbbreviation('California'), 'CA');
-assert.strictEqual(getStateAbbreviation('ca'), 'CA');
-assert.strictEqual(getStateAbbreviation('Texas'), 'TX');
-assert.strictEqual(getStateAbbreviation('unknown'), 'UNKNOWN');
+describe('getStateAbbreviation', () => {
+  test('returns abbreviation for known state names', () => {
+    expect(getStateAbbreviation('California')).toBe('CA');
+    expect(getStateAbbreviation('ca')).toBe('CA');
+    expect(getStateAbbreviation('Texas')).toBe('TX');
+  });
 
-console.log('getStateAbbreviation tests passed');
+  test('returns UNKNOWN for unknown states', () => {
+    expect(getStateAbbreviation('unknown')).toBe('UNKNOWN');
+  });
+});

--- a/tests/parseQueryParams.test.js
+++ b/tests/parseQueryParams.test.js
@@ -1,11 +1,18 @@
-const assert = require('assert');
 const { parseQueryParams } = require('../dist/utils/parseQueryParams.js');
 
-const result = parseQueryParams({ page: '10', search: 'abc', active: true, score: '5.5', other: 'text' });
-assert.strictEqual(result.page, 10);
-assert.strictEqual(result.search, 'abc');
-assert.strictEqual(result.active, true);
-assert.strictEqual(result.score, 5.5);
-assert.strictEqual(result.other, 'text');
-
-console.log('parseQueryParams tests passed');
+describe('parseQueryParams', () => {
+  test('parses query values into the correct types', () => {
+    const result = parseQueryParams({
+      page: '10',
+      search: 'abc',
+      active: true,
+      score: '5.5',
+      other: 'text',
+    });
+    expect(result.page).toBe(10);
+    expect(result.search).toBe('abc');
+    expect(result.active).toBe(true);
+    expect(result.score).toBe(5.5);
+    expect(result.other).toBe('text');
+  });
+});


### PR DESCRIPTION
## Summary
- refactor remaining test suites to use `describe`/`test` with `expect`
- remove leftover `console.log` calls
- ensure `npm test` still builds and runs all tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68513b27b22c8324be401b1ccf291a4a