### PR TITLE
Add environment variable validation

### DIFF
--- a/api/toolsHandler.ts
+++ b/api/toolsHandler.ts
@@ -1,13 +1,17 @@
 // Communication functions
 import { handleToolOptions } from '../functions/handleToolOptions';
 import { verifyRequestToken } from '../utils/verifyJWT';
+import { validateEnv } from '../utils/validateEnv';
 import { toolsMap } from './toolsMap';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 interface AIRequest {
-	functionName: string;
-	[key: string]: any;
+        functionName: string;
+        [key: string]: any;
 }
+
+// Ensure all required environment variables are set when the module loads
+validateEnv();
 
 const handler = async (
         request: VercelRequest,

--- a/api/welcome.ts
+++ b/api/welcome.ts
@@ -2,6 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { verifyRequestToken } from '../utils/verifyJWT';
+import { validateEnv } from '../utils/validateEnv';
+
+// Validate environment on module load
+validateEnv();
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
 	const verification = verifyRequestToken(request);

--- a/functions/communication/sendEmail.ts
+++ b/functions/communication/sendEmail.ts
@@ -1,6 +1,10 @@
 import { GmailMailer } from 'gmail-node-mailer';
+import { validateEnv } from '../../utils/validateEnv';
 import { encodeEmailContent, EncodingType } from '../../utils/encodeEmailContent';
 import { SendEmailMessageRequestParams, SendMessageResponse } from './types';
+
+// Ensure required environment variables are set when the module is imported
+validateEnv();
 
 export const sendEmail = async (request: SendEmailMessageRequestParams): Promise<SendMessageResponse> => {
 	const { to, body, from, subject } = request.body;

--- a/functions/communication/sendTextMessage.ts
+++ b/functions/communication/sendTextMessage.ts
@@ -1,5 +1,9 @@
 import twilio from 'twilio';
+import { validateEnv } from '../../utils/validateEnv';
 import { SendTextMessageRequestParams, SendMessageResponse } from './types';
+
+// Validate required environment variables on import
+validateEnv();
 
 export const sendTextMessage = async (request: SendTextMessageRequestParams): Promise<SendMessageResponse> => {
 	const { TWILIO_ASSISTANT_PHONE_NUMBER, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } = process.env;

--- a/functions/communication/sendWhatsAppMessage.ts
+++ b/functions/communication/sendWhatsAppMessage.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
+import { validateEnv } from '../../utils/validateEnv';
 import { SendWhatsAppMessageRequestParams, SendMessageResponse } from './types';
+
+// Check environment when module loads
+validateEnv();
 
 export const sendWhatsAppMessage = async (request: SendWhatsAppMessageRequestParams): Promise<SendMessageResponse> => {
 	const { WHATSAPP_GRAPH_API_TOKEN, WHATSAPP_GRAPH_API_URL, WHATSAPP_ASSISTANT_PHONE_NUMBER } = process.env;

--- a/utils/validateEnv.ts
+++ b/utils/validateEnv.ts
@@ -1,0 +1,47 @@
+export function validateEnv(): void {
+  const rules: Record<string, RegExp | ((v: string) => boolean)> = {
+    OPENAI_API_KEY: /.+/,
+    OPEN_WEATHER_API_KEY: /.+/,
+    VISUAL_CROSSING_WEATHER_API_KEY: /.+/,
+    DB_USERNAME: /.+/,
+    DB_PASSWORD: /.+/,
+    DB_NAME: /.+/,
+    DB_CLUSTER: /.+/,
+    GDRIVE_SERVICE_ACCOUNT_JSON: (v: string) => {
+      try {
+        JSON.parse(v);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    TRUSTED_API_KEY: /.+/,
+    JWT_SECRET: /.+/,
+    CLOUDINARY_CLOUD_NAME: /.+/,
+    CLOUDINARY_API_KEY: /.+/,
+    CLOUDINARY_API_SECRET: /.+/,
+    AZURE_SPEECH_KEY: /.+/,
+    AZURE_SPEECH_REGION: /.+/,
+    WHATSAPP_GRAPH_API_TOKEN: /.+/,
+    WHATSAPP_GRAPH_API_URL: /^https?:\/\/.+/,
+    WHATSAPP_ASSISTANT_PHONE_NUMBER: /^\+\d{6,}/,
+    TWILIO_ACCOUNT_SID: /.+/,
+    TWILIO_AUTH_TOKEN: /.+/,
+    TWILIO_ASSISTANT_PHONE_NUMBER: /^\+\d{6,}/,
+    GMAIL_MAILER_ASSISTANT_NAME: /.+/,
+    GOOGLE_API_KEY: /.+/,
+    SCALE_SERP_API_KEY: /.+/,
+  };
+  for (const [key, rule] of Object.entries(rules)) {
+    const value = process.env[key];
+    if (!value) {
+      throw new Error(`Missing environment variable: ${key}`);
+    }
+    if (rule instanceof RegExp && !rule.test(value)) {
+      throw new Error(`Invalid format for environment variable: ${key}`);
+    }
+    if (typeof rule === 'function' && !rule(value)) {
+      throw new Error(`Invalid format for environment variable: ${key}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `validateEnv` helper to ensure all required environment variables exist
- check env variables at module load in the API handlers and main communication functions

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685140cf111c8324a1c76f8a47807605