### PR TITLE
Validate env once

### DIFF
--- a/api/getCurrentDateTime.ts
+++ b/api/getCurrentDateTime.ts
@@ -2,10 +2,10 @@ import { find } from 'geo-tz';
 import { VercelRequest } from '@vercel/node';
 import { getLocationData } from '../functions/resolvers/location';
 import { getStateAbbreviation } from '../utils/getStateAbbreviation';
-import { ensureEnv } from '../utils/validateEnv';
+import { validateEnv } from '../utils/validateEnv';
 
 // Validate all required environment variables once on load
-ensureEnv();
+validateEnv();
 
 export const getCurrentDateTime = async (request: VercelRequest) => {
 	let { city, state, zipCode, country, lat, lon } = request.body;

--- a/api/toolsHandler.ts
+++ b/api/toolsHandler.ts
@@ -1,7 +1,7 @@
 // Communication functions
 import { handleToolOptions } from '../functions/handleToolOptions';
 import { verifyRequestToken } from '../utils/verifyJWT';
-import { ensureEnv } from '../utils/validateEnv';
+import { validateEnv } from '../utils/validateEnv';
 import { toolsMap } from './toolsMap';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
@@ -10,8 +10,8 @@ interface AIRequest {
 	[key: string]: any;
 }
 
-// Ensure all required environment variables are set when the module loads
-ensureEnv();
+// Validate all required environment variables once when the module loads
+validateEnv();
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
 	if (request.method === 'OPTIONS') {

--- a/api/welcome.ts
+++ b/api/welcome.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { verifyRequestToken } from '../utils/verifyJWT';
-import { ensureEnv } from '../utils/validateEnv';
+import { validateEnv } from '../utils/validateEnv';
 
 // Validate environment on module load
-ensureEnv();
+validateEnv();
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
 	const verification = verifyRequestToken(request);

--- a/functions/communication/downloadWhatsAppMedia.ts
+++ b/functions/communication/downloadWhatsAppMedia.ts
@@ -3,10 +3,8 @@ import axios from 'axios';
 import OpenAI from 'openai';
 import { cloudinaryConfig } from '../../utils/cloudinaryConfig';
 import { updateCloudinaryMetadata } from '../../utils/updateCloudinaryMetadata';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Ensure env vars for external services are set
-ensureEnv();
+// Environment variables are validated at application startup
 
 const openai = new OpenAI();
 

--- a/functions/communication/listenToWhatsAppVoiceAudio.ts
+++ b/functions/communication/listenToWhatsAppVoiceAudio.ts
@@ -6,10 +6,8 @@ import stream from 'stream';
 import OpenAI from 'openai';
 import { promisify } from 'util';
 import { cloudinaryConfig as cloudinary } from '../../utils/cloudinaryConfig';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables for OpenAI and WhatsApp API
-ensureEnv();
+// Environment variables are validated at application startup
 
 const openai = new OpenAI();
 const pipeline = promisify(stream.pipeline);

--- a/functions/communication/markWhatsAppMessageRead.ts
+++ b/functions/communication/markWhatsAppMessageRead.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables for WhatsApp API
-ensureEnv();
+// Environment variables are validated at application startup
 
 interface MarkWhatsAppMessageReadRequestParams {
 	body: {

--- a/functions/communication/requestWhatsAppLocation.ts
+++ b/functions/communication/requestWhatsAppLocation.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate WhatsApp environment variables on import
-ensureEnv();
+// Environment variables are validated at application startup
 
 interface RequestWhatsAppLocationParams {
 	body: {

--- a/functions/communication/sendEmail.ts
+++ b/functions/communication/sendEmail.ts
@@ -1,10 +1,8 @@
 import { GmailMailer } from 'gmail-node-mailer';
-import { ensureEnv } from '../../utils/validateEnv';
 import { encodeEmailContent, EncodingType } from '../../utils/encodeEmailContent';
 import { SendEmailMessageRequestParams, SendMessageResponse } from './types';
 
-// Ensure required environment variables are set when the module is imported
-ensureEnv();
+// Environment variables are validated at application startup
 
 export const sendEmail = async (request: SendEmailMessageRequestParams): Promise<SendMessageResponse> => {
 	const { to, body, from, subject } = request.body;

--- a/functions/communication/sendTextMessage.ts
+++ b/functions/communication/sendTextMessage.ts
@@ -1,9 +1,7 @@
 import twilio from 'twilio';
-import { ensureEnv } from '../../utils/validateEnv';
 import { SendTextMessageRequestParams, SendMessageResponse } from './types';
 
-// Validate required environment variables on import
-ensureEnv();
+// Environment variables are validated at application startup
 
 export const sendTextMessage = async (request: SendTextMessageRequestParams): Promise<SendMessageResponse> => {
 	const { TWILIO_ASSISTANT_PHONE_NUMBER, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } = process.env;

--- a/functions/communication/sendWhatsAppLocation.ts
+++ b/functions/communication/sendWhatsAppLocation.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables when module is loaded
-ensureEnv();
+// Environment variables are validated at application startup
 
 interface SendWhatsAppLocationRequestParams {
 	body: {

--- a/functions/communication/sendWhatsAppMessage.ts
+++ b/functions/communication/sendWhatsAppMessage.ts
@@ -1,9 +1,7 @@
 import axios from 'axios';
-import { ensureEnv } from '../../utils/validateEnv';
 import { SendWhatsAppMessageRequestParams, SendMessageResponse } from './types';
 
-// Check environment when module loads
-ensureEnv();
+// Environment variables are validated at application startup
 
 export const sendWhatsAppMessage = async (request: SendWhatsAppMessageRequestParams): Promise<SendMessageResponse> => {
 	const { WHATSAPP_GRAPH_API_TOKEN, WHATSAPP_GRAPH_API_URL, WHATSAPP_ASSISTANT_PHONE_NUMBER, WHATSAPP_PHONE_ID } = process.env;

--- a/functions/communication/sendWhatsAppVoiceMessage.ts
+++ b/functions/communication/sendWhatsAppVoiceMessage.ts
@@ -4,10 +4,8 @@ import path from 'path';
 import OpenAI from 'openai';
 import { cloudinaryConfig } from '../../utils/cloudinaryConfig';
 import { SendWhatsAppMessageRequestParams, SendMessageResponse } from './types';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables for OpenAI and WhatsApp API
-ensureEnv();
+// Environment variables are validated at application startup
 
 const openai = new OpenAI();
 

--- a/functions/communication/sendWhatsDocument.ts
+++ b/functions/communication/sendWhatsDocument.ts
@@ -1,10 +1,8 @@
 import axios from 'axios';
 import path from 'path';
 import { SendMessageResponse, SendWhatsAppDocumentRequestParams } from './types';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables on import
-ensureEnv();
+// Environment variables are validated at application startup
 
 export const sendWhatsFile = async (request: SendWhatsAppDocumentRequestParams): Promise<SendMessageResponse> => {
 	const { WHATSAPP_GRAPH_API_TOKEN, WHATSAPP_GRAPH_API_URL, WHATSAPP_ASSISTANT_PHONE_NUMBER, WHATSAPP_PHONE_ID } = process.env;

--- a/functions/communication/viewAndDescribeWhatsAppImage.ts
+++ b/functions/communication/viewAndDescribeWhatsAppImage.ts
@@ -3,10 +3,8 @@ import stream from 'stream';
 import OpenAI from 'openai';
 import { promisify } from 'util';
 import { cloudinaryConfig as cloudinary } from '../../utils/cloudinaryConfig';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate env vars for OpenAI and Cloudinary
-ensureEnv();
+// Environment variables are validated at application startup
 
 const openai = new OpenAI();
 const pipeline = promisify(stream.pipeline);

--- a/functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc.ts
+++ b/functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc.ts
@@ -1,9 +1,7 @@
 import { google } from 'googleapis';
 import { VercelRequest } from '@vercel/node';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate Google Drive service account configuration
-ensureEnv();
+// Environment variables are validated at application startup
 
 function getServiceAccount() {
 	const json = process.env.GDRIVE_SERVICE_ACCOUNT_JSON;

--- a/functions/resolvers/googleAddressResolver.ts
+++ b/functions/resolvers/googleAddressResolver.ts
@@ -1,9 +1,7 @@
 import NodeGeocoder from 'node-geocoder';
 import { VercelRequest } from '@vercel/node';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables when this module is loaded
-ensureEnv();
+// Environment variables are validated at application startup
 
 const geocoder = NodeGeocoder({
 	provider: 'google',

--- a/functions/resolvers/resolveLocation.ts
+++ b/functions/resolvers/resolveLocation.ts
@@ -3,10 +3,8 @@ import gps2zip from 'gps2zip';
 import { connectToMongo } from '../../utils/mongo';
 import { LocationInput, LocationOutput } from '../../types/location';
 import { getStateAbbreviation } from '../../utils/getStateAbbreviation';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Run environment validation once when module is imported
-ensureEnv();
+// Environment variables are validated at application startup
 
 const fetchCoordinates = async (url: string) => {
 	try {

--- a/functions/searchGoogle/googleImageSearch.ts
+++ b/functions/searchGoogle/googleImageSearch.ts
@@ -2,10 +2,8 @@ import axios from 'axios';
 import { VercelRequest } from '@vercel/node';
 import { parseQueryParams } from '../../utils/parseQueryParams';
 import { ImageResult, ImageSearchOptions, ImageSearchResponse } from './searchGoogleTypes';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate API keys used for image search
-ensureEnv();
+// Environment variables are validated at application startup
 
 const fetchImages = async (options: ImageSearchOptions, apiKey: string): Promise<ImageResult[]> => {
 	const params: Record<string, string> = {

--- a/functions/searchGoogle/googleWebSearch.ts
+++ b/functions/searchGoogle/googleWebSearch.ts
@@ -2,10 +2,8 @@ import axios from 'axios';
 import { parseQueryParams } from '../../utils/parseQueryParams';
 import { SerpSearchRequest, WebSearchResponse, WebSearchResult } from './searchGoogleTypes';
 import { VercelRequest } from '@vercel/node';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables for Scale SERP
-ensureEnv();
+// Environment variables are validated at application startup
 
 export const searchGoogle = async (request: VercelRequest): Promise<WebSearchResponse> => {
 	try {

--- a/functions/weather/openWeatherFunction.ts
+++ b/functions/weather/openWeatherFunction.ts
@@ -1,10 +1,8 @@
 import axios from 'axios';
 import { LocationOutput } from '../../types/location';
 import { resolveLocation } from '../resolvers/resolveLocation';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables when the module loads
-ensureEnv();
+// Environment variables are validated at application startup
 
 const fetchWeatherData = async ({ lat, lon, zipCode }: { lat?: number; lon?: number; zipCode?: string }) => {
 	const weatherApiKey = process.env.OPEN_WEATHER_API_KEY;

--- a/functions/weather/todaysWeather.ts
+++ b/functions/weather/todaysWeather.ts
@@ -1,10 +1,8 @@
 import axios from 'axios';
 import { VercelRequest } from '@vercel/node';
 import { WeatherRequest, TodaysWeatherResponse } from './weatherTypes';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate environment variables on import
-ensureEnv();
+// Environment variables are validated at application startup
 
 export const fetchTodaysWeatherData = async (request: VercelRequest): Promise<TodaysWeatherResponse> => {
 	const weatherApiKey = process.env.VISUAL_CROSSING_WEATHER_API_KEY;

--- a/functions/weather/uploaders/uploadToCloudinary.ts
+++ b/functions/weather/uploaders/uploadToCloudinary.ts
@@ -1,10 +1,8 @@
 import { Readable } from 'stream';
 import { VercelRequest } from '@vercel/node';
 import { v2 as cloudinary } from 'cloudinary';
-import { ensureEnv } from '../../../utils/validateEnv';
 
-// Validate env vars for Cloudinary config
-ensureEnv();
+// Environment variables are validated at application startup
 
 cloudinary.config({
 	cloud_name: process.env.CLOUDINARY_CLOUD_NAME,

--- a/functions/weather/visualWeatherFunction.ts
+++ b/functions/weather/visualWeatherFunction.ts
@@ -1,9 +1,7 @@
 import axios from 'axios';
 import { VercelRequest } from '@vercel/node';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Ensure required environment variables are present
-ensureEnv();
+// Environment variables are validated at application startup
 
 const fetchWeatherData = async ({ city, state, country, zipCode, lat, lon }: any) => {
 	const weatherApiKey = process.env.VISUAL_CROSSING_WEATHER_API_KEY;

--- a/functions/webTools/generateLandingPage.ts
+++ b/functions/webTools/generateLandingPage.ts
@@ -2,10 +2,8 @@ import axios from 'axios';
 import { load } from 'cheerio';
 import { VercelRequest } from '@vercel/node';
 import { parseQueryParams } from '../../utils/parseQueryParams';
-import { ensureEnv } from '../../utils/validateEnv';
 
-// Validate OpenAI API configuration
-ensureEnv();
+// Environment variables are validated at application startup
 
 const openaiApiKey = process.env.OPENAI_API_KEY;
 

--- a/utils/azureSpeechConfig.ts
+++ b/utils/azureSpeechConfig.ts
@@ -1,8 +1,6 @@
 import { SpeechConfig } from 'microsoft-cognitiveservices-speech-sdk';
-import { ensureEnv } from './validateEnv';
 
-// Validate environment variables for Azure speech
-ensureEnv();
+// Environment variables are validated on application start
 
 export const AZURE_SPEECH_KEY = process.env.AZURE_SPEECH_KEY;
 export const AZURE_SPEECH_REGION = process.env.AZURE_SPEECH_REGION;

--- a/utils/cloudinaryConfig.ts
+++ b/utils/cloudinaryConfig.ts
@@ -1,8 +1,6 @@
 import { v2 as cloudinary } from 'cloudinary';
-import { ensureEnv } from './validateEnv';
 
-// Validate cloudinary environment variables
-ensureEnv();
+// Cloudinary configuration assumes environment variables are validated elsewhere
 
 const CLOUDINARY_CLOUD_NAME = process.env.CLOUDINARY_CLOUD_NAME;
 const CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY;

--- a/utils/getToken.ts
+++ b/utils/getToken.ts
@@ -4,10 +4,8 @@ import * as path from 'path';
 import FormData from 'form-data';
 import { Collection } from 'mongodb';
 import { connectToMongo } from './mongo';
-import { ensureEnv } from './validateEnv';
 
-// Validate environment variables for token service
-ensureEnv();
+// Token service assumes environment variables are validated at startup
 
 const tokenUrl = process.env.TOKEN_SERVICE_URL || '';
 const apiKey = process.env.TRUSTED_API_KEY || '';

--- a/utils/mongo.ts
+++ b/utils/mongo.ts
@@ -1,8 +1,6 @@
 import { MongoClient, Db, Collection } from 'mongodb';
-import { ensureEnv } from './validateEnv';
 
-// Validate MongoDB environment configuration
-ensureEnv();
+// MongoDB configuration assumes environment variables are validated elsewhere
 
 const { DB_USERNAME: dbUsername = '', DB_PASSWORD: dbPassword = '', DB_NAME: dbName = '', DB_CLUSTER: dbClusterName = '' } = process.env;
 

--- a/utils/updateGoogleDriveFileDescription.ts
+++ b/utils/updateGoogleDriveFileDescription.ts
@@ -1,8 +1,6 @@
 import { google, drive_v3 } from 'googleapis';
-import { ensureEnv } from './validateEnv';
 
-// Validate environment variables for Google Drive access
-ensureEnv();
+// Google Drive configuration assumes environment variables are validated elsewhere
 
 function getServiceAccount() {
 	const json = process.env.GDRIVE_SERVICE_ACCOUNT_JSON;

--- a/utils/validateEnv.ts
+++ b/utils/validateEnv.ts
@@ -18,9 +18,9 @@ export function validateEnv(): void {
 			}
 		},
 		TRUSTED_API_KEY: /.+/,
-                JWT_SECRET: /.+/,
-                TOKEN_SERVICE_URL: /^https?:\/\/.+/,
-                CLOUDINARY_CLOUD_NAME: /.+/,
+		JWT_SECRET: /.+/,
+		TOKEN_SERVICE_URL: /^https?:\/\/.+/,
+		CLOUDINARY_CLOUD_NAME: /.+/,
 		CLOUDINARY_API_KEY: /.+/,
 		CLOUDINARY_API_SECRET: /.+/,
 		AZURE_SPEECH_KEY: /.+/,
@@ -51,11 +51,11 @@ export function validateEnv(): void {
 }
 
 export function ensureEnv(): void {
-        if (process.env.NODE_ENV === 'test') {
-                return;
-        }
-        if (!validated) {
-                validateEnv();
-                validated = true;
-        }
+	if (process.env.NODE_ENV === 'test') {
+		return;
+	}
+	if (!validated) {
+		validateEnv();
+		validated = true;
+	}
 }

--- a/utils/verifyJWT.ts
+++ b/utils/verifyJWT.ts
@@ -1,9 +1,7 @@
 import jwt, { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import type { VercelRequest } from '@vercel/node';
-import { ensureEnv } from './validateEnv';
 
-// Validate JWT_SECRET and related configuration
-ensureEnv();
+// Environment variables are validated at application startup
 
 export type JWTVerificationResult<T> = { valid: true; payload: T } | { valid: false; error: 'expired' | 'malformed' | 'invalid' };
 


### PR DESCRIPTION
## Summary
- run `validateEnv()` once in API entry points
- drop redundant `ensureEnv()` calls across the codebase
- update comments noting env validation is handled at startup

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685336e6d3988324bb944184d56dee46