### PR TITLE
Convert tests back to JS

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/?(*.)+(test).ts'],
+  testMatch: ['**/?(*.)+(test).[jt]s'],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
 };

--- a/tests/convertLength.test.js
+++ b/tests/convertLength.test.js
@@ -1,11 +1,11 @@
-import { convertLength } from '../functions/unitConversion/convertLength';
+const { convertLength } = require('../functions/unitConversion/convertLength.ts');
 
 describe('convertLength', () => {
   test('converts meters to feet', async () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'meters', to: 'feet', value: '1' },
-    } as any);
+    });
     expect(result.status).toBe(true);
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
@@ -20,7 +20,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'POST',
       body: { from: 'feet', to: 'meters', value: 3.28 },
-    } as any);
+    });
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: true,
@@ -34,7 +34,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'inches', to: 'centimeters', value: '1' },
-    } as any);
+    });
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: true,
@@ -48,7 +48,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'centimeters', to: 'inches', value: '2.54' },
-    } as any);
+    });
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: true,
@@ -62,7 +62,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'yards', to: 'meters', value: '1' },
-    } as any);
+    });
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: false,
@@ -76,7 +76,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'meters', to: 'feet', value: 'abc' },
-    } as any);
+    });
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: false,
@@ -91,7 +91,7 @@ describe('convertLength', () => {
       to: 'feet',
       value: 1,
     }));
-    const result = await convertLength({ method: 'POST', body: many } as any);
+    const result = await convertLength({ method: 'POST', body: many });
     expect(result).toEqual({
       status: false,
       message:

--- a/tests/encodeEmailContent.test.js
+++ b/tests/encodeEmailContent.test.js
@@ -1,4 +1,4 @@
-import { encodeEmailContent, EncodingType } from '../utils/encodeEmailContent';
+const { encodeEmailContent, EncodingType } = require('../utils/encodeEmailContent.ts');
 
 describe('encodeEmailContent', () => {
   test('subject encoding', () => {

--- a/tests/getStateAbbreviation.test.js
+++ b/tests/getStateAbbreviation.test.js
@@ -1,4 +1,4 @@
-import { getStateAbbreviation } from '../utils/getStateAbbreviation';
+const { getStateAbbreviation } = require('../utils/getStateAbbreviation.ts');
 
 describe('getStateAbbreviation', () => {
   test('returns abbreviation for known state names', () => {

--- a/tests/getWebsiteScreenshot.test.js
+++ b/tests/getWebsiteScreenshot.test.js
@@ -1,14 +1,13 @@
 jest.setTimeout(15000);
-import { getWebsiteScreenshot } from '../functions/screenshot/getWebsiteScreenshot';
-import puppeteer from 'puppeteer-extra';
-import { uploadGDriveHelper } from '../utils/getToken';
-
 jest.mock('puppeteer-extra');
 jest.mock('puppeteer-extra-plugin-stealth', () => jest.fn(() => ({})));
 jest.mock('../utils/getToken');
+const { getWebsiteScreenshot } = require('../functions/screenshot/getWebsiteScreenshot.ts');
+const puppeteer = require('puppeteer-extra');
+const { uploadGDriveHelper } = require('../utils/getToken.ts');
 
-const mockedPuppeteer = puppeteer as jest.Mocked<typeof puppeteer>;
-const mockedUpload = uploadGDriveHelper as jest.MockedFunction<typeof uploadGDriveHelper>;
+const mockedPuppeteer = /** @type {jest.Mocked<typeof puppeteer>} */ (puppeteer);
+const mockedUpload = /** @type {jest.MockedFunction<typeof uploadGDriveHelper>} */ (uploadGDriveHelper);
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -24,7 +23,7 @@ beforeEach(() => {
         },
       ],
     },
-  } as any);
+  });
 
   const page = {
     setViewport: jest.fn(),
@@ -33,12 +32,12 @@ beforeEach(() => {
     goto: jest.fn(),
     mouse: { move: jest.fn(), click: jest.fn() },
     screenshot: jest.fn().mockResolvedValue(Buffer.from('img')),
-  } as any;
+  };
 
   const browser = {
     newPage: jest.fn().mockResolvedValue(page),
     close: jest.fn(),
-  } as any;
+  };
 
   mockedPuppeteer.launch = jest.fn().mockResolvedValue(browser);
   mockedPuppeteer.use = jest.fn();
@@ -49,7 +48,7 @@ afterEach(() => {
 });
 
 test('captures screenshot and uploads', async () => {
-  const promise = getWebsiteScreenshot({ method: 'GET', query: { url: 'https://example.com' } } as any);
+  const promise = getWebsiteScreenshot({ method: 'GET', query: { url: 'https://example.com' } });
   await jest.runAllTimersAsync();
   const result = await promise;
   expect(result).toEqual(

--- a/tests/parseQueryParams.test.js
+++ b/tests/parseQueryParams.test.js
@@ -1,14 +1,14 @@
-import { parseQueryParams } from '../utils/parseQueryParams';
+const { parseQueryParams } = require('../utils/parseQueryParams.ts');
 
 describe('parseQueryParams', () => {
   test('parses query values into the correct types', () => {
     const result = parseQueryParams({
       page: '10',
       search: 'abc',
-      active: true as any,
+      active: true,
       score: '5.5',
       other: 'text',
-    } as any);
+    });
     expect(result.page).toBe(10);
     expect(result.search).toBe('abc');
     expect(result.active).toBe(true);

--- a/tests/sanitizeFilename.test.js
+++ b/tests/sanitizeFilename.test.js
@@ -1,4 +1,4 @@
-import { sanitizeFilename } from '../utils/sanitizeFilename';
+const { sanitizeFilename } = require('../utils/sanitizeFilename.ts');
 
 describe('sanitizeFilename', () => {
   test('removes http or https protocol', () => {

--- a/tests/searchGoogle.test.js
+++ b/tests/searchGoogle.test.js
@@ -1,9 +1,8 @@
-import axios from 'axios';
-import { searchGoogle } from '../functions/searchGoogle/googleWebSearch';
-
 jest.mock('axios');
+const axios = require('axios');
+const { searchGoogle } = require('../functions/searchGoogle/googleWebSearch.ts');
 
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedAxios = /** @type {jest.Mocked<typeof axios>} */ (axios);
 
 describe('searchGoogle', () => {
   beforeEach(() => {
@@ -26,7 +25,7 @@ describe('searchGoogle', () => {
   });
 
   test('returns search results', async () => {
-    const result = await searchGoogle({ method: 'GET', query: { searchTerm: 'test' } } as any);
+    const result = await searchGoogle({ method: 'GET', query: { searchTerm: 'test' } });
     expect(result).toEqual(
       expect.objectContaining({
         status: true,

--- a/tests/sendTextMessage.test.js
+++ b/tests/sendTextMessage.test.js
@@ -1,9 +1,8 @@
-import { sendTextMessage } from '../functions/communication/sendTextMessage';
-import twilio from 'twilio';
-
 jest.mock('twilio');
+const { sendTextMessage } = require('../functions/communication/sendTextMessage.ts');
+const twilio = require('twilio');
 
-const mockedTwilio = twilio as jest.MockedFunction<typeof twilio>;
+const mockedTwilio = /** @type {jest.MockedFunction<typeof twilio>} */ (twilio);
 
 describe('sendTextMessage', () => {
   beforeEach(() => {
@@ -16,11 +15,11 @@ describe('sendTextMessage', () => {
       messages: {
         create: jest.fn().mockResolvedValue({ status: 'sent', sid: '123' }),
       },
-    } as any);
+    });
   });
 
   test('sends text message successfully', async () => {
-    const result = await sendTextMessage({ body: { to: '+1', body: 'hi' } } as any);
+    const result = await sendTextMessage({ body: { to: '+1', body: 'hi' } });
     expect(result).toEqual(
       expect.objectContaining({ success: true, msgId: '123' }),
     );

--- a/tests/verifyJWT.test.js
+++ b/tests/verifyJWT.test.js
@@ -1,5 +1,5 @@
-import jwt from 'jsonwebtoken';
-import { verifyJWT } from '../utils/verifyJWT';
+const jwt = require('jsonwebtoken');
+const { verifyJWT } = require('../utils/verifyJWT.ts');
 
 describe('verifyJWT', () => {
   beforeAll(() => {
@@ -7,7 +7,7 @@ describe('verifyJWT', () => {
   });
 
   test('valid token', () => {
-    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET as string, {
+    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET, {
       algorithm: 'HS256',
       expiresIn: '1h',
     });
@@ -17,7 +17,7 @@ describe('verifyJWT', () => {
   });
 
   test('expired token', () => {
-    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET as string, {
+    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET, {
       algorithm: 'HS256',
       expiresIn: -10,
     });


### PR DESCRIPTION
## Summary
- convert all test files from TypeScript to JavaScript
- update Jest config to include `.js` tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68533c07b0488324ac0d8a81c5d61fb4